### PR TITLE
 bug fix in setup.py . undefined reference to "root"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,9 @@ def check_root():
 
 class CustomInstall(install):
     def run(self):
-        if not hasattr(self,"root") or 'debian' not in self.root:
+        if not hasattr(self,"root"):
+            install_udev_rules(True)
+        elif 'debian' not in self.root:
             install_udev_rules(True)
         install.run(self)
 


### PR DESCRIPTION
the line ` if not hasattr(self,"root") or 'debian' not in self.root:` is incorrect. presence of self.root should be checked before referring to it as an array in `'debian' not in self.root`