### PR TITLE
Fix broken initialization on Python 3

### DIFF
--- a/PSL/Peripherals.py
+++ b/PSL/Peripherals.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-import commands_proto as CP
+import PSL.commands_proto as CP
 import numpy as np
 import time, inspect
 

--- a/PSL/sciencelab.py
+++ b/PSL/sciencelab.py
@@ -2864,7 +2864,7 @@ class ScienceLab():
             self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
 
     def __stoa__(self, s):
-        return [ord(a) for a in s]
+        return [ord(a) for a in s.decode('utf-8')]
 
     def __atos__(self, a):
         return ''.join(chr(e) for e in a)


### PR DESCRIPTION
Two lines need to be fixed to run pslab on Python 3.6 (macOS):
1. correctly import _commands_proto_ in _Peripherals.py_,
2. correctly decode bytes in _sciencelab.py_.