### PR TITLE
Travis CI add Python 3.7, 3.8 find undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 
 install:
     - pip3 install flake8 -r requirements.txt
-    - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    - flake8 . --select=E9,F63,F7,F82 --show-source --statistics
     - sudo env "PATH=$PATH" make clean
     - make all
     - sudo env "PATH=$PATH" make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
 
-sudo: true
-
 python:
-    - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
+    - "3.8"
 
 before_install:
     - sudo apt-get -qq update
@@ -13,7 +12,8 @@ before_install:
     - sudo chmod a+rw /builds
 
 install:
-    - pip3 install -r requirements.txt
+    - pip3 install flake8 -r requirements.txt
+    - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     - sudo env "PATH=$PATH" make clean
     - make all
     - sudo env "PATH=$PATH" make install


### PR DESCRIPTION
~Blocked by #83~

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.