### PR TITLE
Handle conflict in namespace 'serial'

### DIFF
--- a/PSL/packet_handler.py
+++ b/PSL/packet_handler.py
@@ -5,6 +5,13 @@ import time
 import inspect
 import serial
 
+# Handle namespace conflict between packages 'pyserial' and 'serial'.
+try:
+    serial.Serial
+except AttributeError:
+    e = "import serial failed; PSL requires 'pyserial' but conflicting package 'serial' was found."
+    raise ImportError(e)
+
 import PSL.commands_proto as CP
 
 


### PR DESCRIPTION
The packages 'pyserial' and 'serial' both use the 'serial' namespace. Therefore, `import serial` will succeed if the user has the latter package installed, even though PSL needs the former. This results in an unhelpful "Could not connect" RuntimeError down the line.

With this change, PSL verifies that the correct 'serial' was imported, and complains otherwise.