### PR TITLE
Remove custom exception handling

### DIFF
--- a/PSL/Peripherals.py
+++ b/PSL/Peripherals.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import PSL.commands_proto as CP
 import numpy as np
-import time, inspect
+import time
 
 
 class I2C():
@@ -46,20 +46,14 @@ class I2C():
         self.buff = np.zeros(10000)
 
     def init(self):
-        try:
-            self.H.__sendByte__(CP.I2C_HEADER)
-            self.H.__sendByte__(CP.I2C_INIT)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.I2C_HEADER)
+        self.H.__sendByte__(CP.I2C_INIT)
+        self.H.__get_ack__()
 
     def enable_smbus(self):
-        try:
-            self.H.__sendByte__(CP.I2C_HEADER)
-            self.H.__sendByte__(CP.I2C_ENABLE_SMBUS)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.I2C_HEADER)
+        self.H.__sendByte__(CP.I2C_ENABLE_SMBUS)
+        self.H.__get_ack__()
 
     def pullSCLLow(self, uS):
         """
@@ -75,13 +69,10 @@ class I2C():
         ================    ============================================================================================
 
         """
-        try:
-            self.H.__sendByte__(CP.I2C_HEADER)
-            self.H.__sendByte__(CP.I2C_PULLDOWN_SCL)
-            self.H.__sendInt__(uS)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.I2C_HEADER)
+        self.H.__sendByte__(CP.I2C_PULLDOWN_SCL)
+        self.H.__sendInt__(uS)
+        self.H.__get_ack__()
 
     def config(self, freq, verbose=True):
         """
@@ -95,18 +86,15 @@ class I2C():
         freq                I2C frequency
         ================    ============================================================================================
         """
-        try:
-            self.H.__sendByte__(CP.I2C_HEADER)
-            self.H.__sendByte__(CP.I2C_CONFIG)
-            # freq=1/((BRGVAL+1.0)/64e6+1.0/1e7)
-            BRGVAL = int((1. / freq - 1. / 1e7) * 64e6 - 1)
-            if BRGVAL > 511:
-                BRGVAL = 511
-                if verbose: print('Frequency too low. Setting to :', 1 / ((BRGVAL + 1.0) / 64e6 + 1.0 / 1e7))
-            self.H.__sendInt__(BRGVAL)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.I2C_HEADER)
+        self.H.__sendByte__(CP.I2C_CONFIG)
+        # freq=1/((BRGVAL+1.0)/64e6+1.0/1e7)
+        BRGVAL = int((1. / freq - 1. / 1e7) * 64e6 - 1)
+        if BRGVAL > 511:
+            BRGVAL = 511
+            if verbose: print('Frequency too low. Setting to :', 1 / ((BRGVAL + 1.0) / 64e6 + 1.0 / 1e7))
+        self.H.__sendInt__(BRGVAL)
+        self.H.__get_ack__()
 
     def start(self, address, rw):
         """
@@ -123,13 +111,10 @@ class I2C():
                             - 1 for reading.
         ================    ============================================================================================
         """
-        try:
-            self.H.__sendByte__(CP.I2C_HEADER)
-            self.H.__sendByte__(CP.I2C_START)
-            self.H.__sendByte__(((address << 1) | rw) & 0xFF)  # address
-            return self.H.__get_ack__() >> 4
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.I2C_HEADER)
+        self.H.__sendByte__(CP.I2C_START)
+        self.H.__sendByte__(((address << 1) | rw) & 0xFF)  # address
+        return self.H.__get_ack__() >> 4
 
     def stop(self):
         """
@@ -137,12 +122,9 @@ class I2C():
 
         :return: Nothing
         """
-        try:
-            self.H.__sendByte__(CP.I2C_HEADER)
-            self.H.__sendByte__(CP.I2C_STOP)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.I2C_HEADER)
+        self.H.__sendByte__(CP.I2C_STOP)
+        self.H.__get_ack__()
 
     def wait(self):
         """
@@ -150,12 +132,9 @@ class I2C():
 
         :return: Nothing
         """
-        try:
-            self.H.__sendByte__(CP.I2C_HEADER)
-            self.H.__sendByte__(CP.I2C_WAIT)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.I2C_HEADER)
+        self.H.__sendByte__(CP.I2C_WAIT)
+        self.H.__get_ack__()
 
     def send(self, data):
         """
@@ -173,13 +152,10 @@ class I2C():
 
         :return: Nothing
         """
-        try:
-            self.H.__sendByte__(CP.I2C_HEADER)
-            self.H.__sendByte__(CP.I2C_SEND)
-            self.H.__sendByte__(data)  # data byte
-            return self.H.__get_ack__() >> 4
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.I2C_HEADER)
+        self.H.__sendByte__(CP.I2C_SEND)
+        self.H.__sendByte__(data)  # data byte
+        return self.H.__get_ack__() >> 4
 
     def send_burst(self, data):
         """
@@ -198,13 +174,10 @@ class I2C():
 
         :return: Nothing
         """
-        try:
-            self.H.__sendByte__(CP.I2C_HEADER)
-            self.H.__sendByte__(CP.I2C_SEND_BURST)
-            self.H.__sendByte__(data)  # data byte
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
-            # No handshake. for the sake of speed. e.g. loading a frame buffer onto an I2C display such as ssd1306
+        self.H.__sendByte__(CP.I2C_HEADER)
+        self.H.__sendByte__(CP.I2C_SEND_BURST)
+        self.H.__sendByte__(data)  # data byte
+        # No handshake. for the sake of speed. e.g. loading a frame buffer onto an I2C display such as ssd1306
 
     def restart(self, address, rw):
         """
@@ -222,12 +195,9 @@ class I2C():
         ================    ============================================================================================
 
         """
-        try:
-            self.H.__sendByte__(CP.I2C_HEADER)
-            self.H.__sendByte__(CP.I2C_RESTART)
-            self.H.__sendByte__(((address << 1) | rw) & 0xFF)  # address
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.I2C_HEADER)
+        self.H.__sendByte__(CP.I2C_RESTART)
+        self.H.__sendByte__(((address << 1) | rw) & 0xFF)  # address
         return self.H.__get_ack__() >> 4
 
     def simpleRead(self, addr, numbytes):
@@ -261,66 +231,53 @@ class I2C():
         ================    ============================================================================================
         """
         data = []
-        try:
-            for a in range(length - 1):
-                self.H.__sendByte__(CP.I2C_HEADER)
-                self.H.__sendByte__(CP.I2C_READ_MORE)
-                data.append(self.H.__getByte__())
-                self.H.__get_ack__()
+
+        for a in range(length - 1):
             self.H.__sendByte__(CP.I2C_HEADER)
-            self.H.__sendByte__(CP.I2C_READ_END)
+            self.H.__sendByte__(CP.I2C_READ_MORE)
             data.append(self.H.__getByte__())
             self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.I2C_HEADER)
+        self.H.__sendByte__(CP.I2C_READ_END)
+        data.append(self.H.__getByte__())
+        self.H.__get_ack__()
+
         return data
 
     def read_repeat(self):
-        try:
-            self.H.__sendByte__(CP.I2C_HEADER)
-            self.H.__sendByte__(CP.I2C_READ_MORE)
-            val = self.H.__getByte__()
-            self.H.__get_ack__()
-            return val
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.I2C_HEADER)
+        self.H.__sendByte__(CP.I2C_READ_MORE)
+        val = self.H.__getByte__()
+        self.H.__get_ack__()
+        return val
 
     def read_end(self):
-        try:
-            self.H.__sendByte__(CP.I2C_HEADER)
-            self.H.__sendByte__(CP.I2C_READ_END)
-            val = self.H.__getByte__()
-            self.H.__get_ack__()
-            return val
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.I2C_HEADER)
+        self.H.__sendByte__(CP.I2C_READ_END)
+        val = self.H.__getByte__()
+        self.H.__get_ack__()
+        return val
 
     def read_status(self):
-        try:
-            self.H.__sendByte__(CP.I2C_HEADER)
-            self.H.__sendByte__(CP.I2C_STATUS)
-            val = self.H.__getInt__()
-            self.H.__get_ack__()
-            return val
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.I2C_HEADER)
+        self.H.__sendByte__(CP.I2C_STATUS)
+        val = self.H.__getInt__()
+        self.H.__get_ack__()
+        return val
 
     def readBulk(self, device_address, register_address, bytes_to_read):
+        self.H.__sendByte__(CP.I2C_HEADER)
+        self.H.__sendByte__(CP.I2C_READ_BULK)
+        self.H.__sendByte__(device_address)
+        self.H.__sendByte__(register_address)
+        self.H.__sendByte__(bytes_to_read)
+        data = self.H.fd.read(bytes_to_read)
+        self.H.__get_ack__()
         try:
-            self.H.__sendByte__(CP.I2C_HEADER)
-            self.H.__sendByte__(CP.I2C_READ_BULK)
-            self.H.__sendByte__(device_address)
-            self.H.__sendByte__(register_address)
-            self.H.__sendByte__(bytes_to_read)
-            data = self.H.fd.read(bytes_to_read)
-            self.H.__get_ack__()
-            try:
-                return list(data)
-            except:
-                print('Transaction failed')
-                return False
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+            return list(data)
+        except:
+            print('Transaction failed')
+            return False
 
     def writeBulk(self, device_address, bytestream):
         """
@@ -335,16 +292,13 @@ class I2C():
         bytestream          List of bytes to write
         ================    ============================================================================================
         """
-        try:
-            self.H.__sendByte__(CP.I2C_HEADER)
-            self.H.__sendByte__(CP.I2C_WRITE_BULK)
-            self.H.__sendByte__(device_address)
-            self.H.__sendByte__(len(bytestream))
-            for a in bytestream:
-                self.H.__sendByte__(a)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.I2C_HEADER)
+        self.H.__sendByte__(CP.I2C_WRITE_BULK)
+        self.H.__sendByte__(device_address)
+        self.H.__sendByte__(len(bytestream))
+        for a in bytestream:
+            self.H.__sendByte__(a)
+        self.H.__get_ack__()
 
     def scan(self, frequency=100000, verbose=False):
         """
@@ -382,7 +336,7 @@ class I2C():
         Blocking call that starts fetching data from I2C sensors like an oscilloscope fetches voltage readings
         You will then have to call `__retrievebuffer__` to fetch this data, and `__dataProcessor` to process and return separate channels
         refer to `capture` if you want a one-stop solution.
-        
+
         .. tabularcolumns:: |p{3cm}|p{11cm}|
         ==================  ============================================================================================
         **Arguments**
@@ -469,7 +423,7 @@ class I2C():
     def __dataProcessor__(self, data, *args):
         '''
         Interpret data acquired by the I2C scope. refer to :func:`__retrievebuffer__` to fetch data
-        
+
         ==================  ============================================================================================
         **Arguments**
         ==================  ============================================================================================
@@ -478,21 +432,16 @@ class I2C():
         ==================  ============================================================================================
 
         '''
+        data = [ord(a) for a in data]
+        if ('int' in args):
+            for a in range(self.channels * self.samples / 2): self.buff[a] = np.int16(
+                (data[a * 2] << 8) | data[a * 2 + 1])
+        else:
+            for a in range(self.channels * self.samples): self.buff[a] = data[a]
 
-        try:
-            data = [ord(a) for a in data]
-            if ('int' in args):
-                for a in range(self.channels * self.samples / 2): self.buff[a] = np.int16(
-                    (data[a * 2] << 8) | data[a * 2 + 1])
-            else:
-                for a in range(self.channels * self.samples): self.buff[a] = data[a]
-
-            yield np.linspace(0, self.tg * (self.samples - 1), self.samples)
-            for a in range(int(self.channels / 2)):
-                yield self.buff[a:self.samples * self.channels / 2][::self.channels / 2]
-        except Exception as ex:
-            msg = "Incorrect number of bytes received", ex
-            raise RuntimeError(msg)
+        yield np.linspace(0, self.tg * (self.samples - 1), self.samples)
+        for a in range(int(self.channels / 2)):
+            yield self.buff[a:self.samples * self.channels / 2][::self.channels / 2]
 
     def capture(self, address, location, sample_length, total_samples, tg, *args):
         """
@@ -555,14 +504,11 @@ class SPI():
         ================    ============================================================================================
 
         """
-        try:
-            self.H.__sendByte__(CP.SPI_HEADER)
-            self.H.__sendByte__(CP.SET_SPI_PARAMETERS)
-            # 0Bhgfedcba - > <g>: modebit CKP,<f>: modebit CKE, <ed>:primary pre,<cba>:secondary pre
-            self.H.__sendByte__(secondary_prescaler | (primary_prescaler << 3) | (CKE << 5) | (CKP << 6) | (SMP << 7))
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.SPI_HEADER)
+        self.H.__sendByte__(CP.SET_SPI_PARAMETERS)
+        # 0Bhgfedcba - > <g>: modebit CKP,<f>: modebit CKE, <ed>:primary pre,<cba>:secondary pre
+        self.H.__sendByte__(secondary_prescaler | (primary_prescaler << 3) | (CKE << 5) | (CKP << 6) | (SMP << 7))
+        self.H.__get_ack__()
 
     def start(self, channel):
         """
@@ -580,13 +526,10 @@ class SPI():
         ================    ============================================================================================
 
         """
-        try:
-            self.H.__sendByte__(CP.SPI_HEADER)
-            self.H.__sendByte__(CP.START_SPI)
-            self.H.__sendByte__(channel)  # value byte
+        self.H.__sendByte__(CP.SPI_HEADER)
+        self.H.__sendByte__(CP.START_SPI)
+        self.H.__sendByte__(channel)  # value byte
         # self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
 
     def set_cs(self, channel, state):
         """
@@ -602,20 +545,17 @@ class SPI():
         ================    ============================================================================================
 
         """
-        try:
-            channel = channel.upper()
-            if channel in ['CS1', 'CS2']:
-                csnum = ['CS1', 'CS2'].index(channel) + 9  # chip select number 9=CSOUT1,10=CSOUT2
-                self.H.__sendByte__(CP.SPI_HEADER)
-                if state:
-                    self.H.__sendByte__(CP.STOP_SPI)
-                else:
-                    self.H.__sendByte__(CP.START_SPI)
-                self.H.__sendByte__(csnum)
+        channel = channel.upper()
+        if channel in ['CS1', 'CS2']:
+            csnum = ['CS1', 'CS2'].index(channel) + 9  # chip select number 9=CSOUT1,10=CSOUT2
+            self.H.__sendByte__(CP.SPI_HEADER)
+            if state:
+                self.H.__sendByte__(CP.STOP_SPI)
             else:
-                print('Channel does not exist')
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+                self.H.__sendByte__(CP.START_SPI)
+            self.H.__sendByte__(csnum)
+        else:
+            print('Channel does not exist')
 
     def stop(self, channel):
         """
@@ -632,13 +572,10 @@ class SPI():
 
 
         """
-        try:
-            self.H.__sendByte__(CP.SPI_HEADER)
-            self.H.__sendByte__(CP.STOP_SPI)
-            self.H.__sendByte__(channel)  # value byte
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
-            # self.H.__get_ack__()
+        self.H.__sendByte__(CP.SPI_HEADER)
+        self.H.__sendByte__(CP.STOP_SPI)
+        self.H.__sendByte__(channel)  # value byte
+        # self.H.__get_ack__()
 
     def send8(self, value):
         """
@@ -654,15 +591,12 @@ class SPI():
 
         :return: value returned by slave device
         """
-        try:
-            self.H.__sendByte__(CP.SPI_HEADER)
-            self.H.__sendByte__(CP.SEND_SPI8)
-            self.H.__sendByte__(value)  # value byte
-            v = self.H.__getByte__()
-            self.H.__get_ack__()
-            return v
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.SPI_HEADER)
+        self.H.__sendByte__(CP.SEND_SPI8)
+        self.H.__sendByte__(value)  # value byte
+        v = self.H.__getByte__()
+        self.H.__get_ack__()
+        return v
 
     def send16(self, value):
         """
@@ -679,15 +613,12 @@ class SPI():
         :return: value returned by slave device
         :rtype: int
         """
-        try:
-            self.H.__sendByte__(CP.SPI_HEADER)
-            self.H.__sendByte__(CP.SEND_SPI16)
-            self.H.__sendInt__(value)  # value byte
-            v = self.H.__getInt__()
-            self.H.__get_ack__()
-            return v
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.SPI_HEADER)
+        self.H.__sendByte__(CP.SEND_SPI16)
+        self.H.__sendInt__(value)  # value byte
+        v = self.H.__getInt__()
+        self.H.__get_ack__()
+        return v
 
     def send8_burst(self, value):
         """
@@ -704,12 +635,9 @@ class SPI():
 
         :return: Nothing
         """
-        try:
-            self.H.__sendByte__(CP.SPI_HEADER)
-            self.H.__sendByte__(CP.SEND_SPI8_BURST)
-            self.H.__sendByte__(value)  # value byte
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.SPI_HEADER)
+        self.H.__sendByte__(CP.SEND_SPI8_BURST)
+        self.H.__sendByte__(value)  # value byte
 
     def send16_burst(self, value):
         """
@@ -726,12 +654,9 @@ class SPI():
 
         :return: nothing
         """
-        try:
-            self.H.__sendByte__(CP.SPI_HEADER)
-            self.H.__sendByte__(CP.SEND_SPI16_BURST)
-            self.H.__sendInt__(value)  # value byte
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.SPI_HEADER)
+        self.H.__sendByte__(CP.SEND_SPI16_BURST)
+        self.H.__sendInt__(value)  # value byte
 
     def xfer(self, chan, data):
         self.start(chan)
@@ -941,47 +866,38 @@ class NRF24L01():
     """
 
     def init(self):
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_SETUP)
-            self.H.__get_ack__()
-            time.sleep(0.015)  # 15 mS settling time
-            stat = self.get_status()
-            if stat & 0x80:
-                print("Radio transceiver not installed/not found")
-                return False
-            else:
-                self.ready = True
-            self.selectAddress(self.CURRENT_ADDRESS)
-            # self.write_register(self.RF_SETUP,0x06)
-            self.rxmode()
-            time.sleep(0.1)
-            self.flush()
-            return True
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_SETUP)
+        self.H.__get_ack__()
+        time.sleep(0.015)  # 15 mS settling time
+        stat = self.get_status()
+        if stat & 0x80:
+            print("Radio transceiver not installed/not found")
+            return False
+        else:
+            self.ready = True
+        self.selectAddress(self.CURRENT_ADDRESS)
+        # self.write_register(self.RF_SETUP,0x06)
+        self.rxmode()
+        time.sleep(0.1)
+        self.flush()
+        return True
 
     def rxmode(self):
         '''
         Puts the radio into listening mode.
         '''
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_RXMODE)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_RXMODE)
+        self.H.__get_ack__()
 
     def txmode(self):
         '''
         Puts the radio into transmit mode.
         '''
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_TXMODE)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_TXMODE)
+        self.H.__get_ack__()
 
     def triggerAll(self, val):
         self.txmode()
@@ -991,61 +907,46 @@ class NRF24L01():
         self.write_register(self.EN_AA, 0x01)
 
     def power_down(self):
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_POWER_DOWN)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_POWER_DOWN)
+        self.H.__get_ack__()
 
     def rxchar(self):
         '''
         Receives a 1 Byte payload
         '''
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_RXCHAR)
-            value = self.H.__getByte__()
-            self.H.__get_ack__()
-            return value
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_RXCHAR)
+        value = self.H.__getByte__()
+        self.H.__get_ack__()
+        return value
 
     def txchar(self, char):
         '''
         Transmits a single character
         '''
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_TXCHAR)
-            self.H.__sendByte__(char)
-            return self.H.__get_ack__() >> 4
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_TXCHAR)
+        self.H.__sendByte__(char)
+        return self.H.__get_ack__() >> 4
 
     def hasData(self):
         '''
         Check if the RX FIFO contains data
         '''
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_HASDATA)
-            value = self.H.__getByte__()
-            self.H.__get_ack__()
-            return value
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_HASDATA)
+        value = self.H.__getByte__()
+        self.H.__get_ack__()
+        return value
 
     def flush(self):
         '''
         Flushes the TX and RX FIFOs
         '''
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_FLUSH)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_FLUSH)
+        self.H.__get_ack__()
 
     def write_register(self, address, value):
         '''
@@ -1054,52 +955,40 @@ class NRF24L01():
         from some of the constants defined in this module.
         '''
         # print ('writing',address,value)
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_WRITEREG)
-            self.H.__sendByte__(address)
-            self.H.__sendByte__(value)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_WRITEREG)
+        self.H.__sendByte__(address)
+        self.H.__sendByte__(value)
+        self.H.__get_ack__()
 
     def read_register(self, address):
         '''
         Read the value of any of the configuration registers on the radio module.
 
         '''
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_READREG)
-            self.H.__sendByte__(address)
-            val = self.H.__getByte__()
-            self.H.__get_ack__()
-            return val
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_READREG)
+        self.H.__sendByte__(address)
+        val = self.H.__getByte__()
+        self.H.__get_ack__()
+        return val
 
     def get_status(self):
         '''
         Returns a byte representing the STATUS register on the radio.
         Refer to NRF24L01+ documentation for further details
         '''
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_GETSTATUS)
-            val = self.H.__getByte__()
-            self.H.__get_ack__()
-            return val
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_GETSTATUS)
+        val = self.H.__getByte__()
+        self.H.__get_ack__()
+        return val
 
     def write_command(self, cmd):
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_WRITECOMMAND)
-            self.H.__sendByte__(cmd)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_WRITECOMMAND)
+        self.H.__sendByte__(cmd)
+        self.H.__get_ack__()
 
     def write_address(self, register, address):
         '''
@@ -1109,67 +998,55 @@ class NRF24L01():
         from P2 to P5, then RX_ADDR_P1 must be updated last.
         Addresses from P1-P5 must share the first two bytes.
         '''
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_WRITEADDRESS)
-            self.H.__sendByte__(register)
-            self.H.__sendByte__(address & 0xFF)
-            self.H.__sendByte__((address >> 8) & 0xFF)
-            self.H.__sendByte__((address >> 16) & 0xFF)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_WRITEADDRESS)
+        self.H.__sendByte__(register)
+        self.H.__sendByte__(address & 0xFF)
+        self.H.__sendByte__((address >> 8) & 0xFF)
+        self.H.__sendByte__((address >> 16) & 0xFF)
+        self.H.__get_ack__()
 
     def selectAddress(self, address):
         '''
         Sets RX_ADDR_P0 and TX_ADDR to the specified address.
 
         '''
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_WRITEADDRESSES)
-            self.H.__sendByte__(address & 0xFF)
-            self.H.__sendByte__((address >> 8) & 0xFF)
-            self.H.__sendByte__((address >> 16) & 0xFF)
-            self.H.__get_ack__()
-            self.CURRENT_ADDRESS = address
-            if address not in self.sigs:
-                self.sigs[address] = 1
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_WRITEADDRESSES)
+        self.H.__sendByte__(address & 0xFF)
+        self.H.__sendByte__((address >> 8) & 0xFF)
+        self.H.__sendByte__((address >> 16) & 0xFF)
+        self.H.__get_ack__()
+        self.CURRENT_ADDRESS = address
+        if address not in self.sigs:
+            self.sigs[address] = 1
 
     def read_payload(self, numbytes):
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_READPAYLOAD)
-            self.H.__sendByte__(numbytes)
-            data = self.H.fd.read(numbytes)
-            self.H.__get_ack__()
-            return [ord(a) for a in data]
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_READPAYLOAD)
+        self.H.__sendByte__(numbytes)
+        data = self.H.fd.read(numbytes)
+        self.H.__get_ack__()
+        return [ord(a) for a in data]
 
     def write_payload(self, data, verbose=False, **args):
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_WRITEPAYLOAD)
-            numbytes = len(
-                data) | 0x80  # 0x80 implies transmit immediately. Otherwise it will simply load the TX FIFO ( used by ACK_payload)
-            if (args.get('rxmode', False)): numbytes |= 0x40
-            self.H.__sendByte__(numbytes)
-            self.H.__sendByte__(self.TX_PAYLOAD)
-            for a in data:
-                self.H.__sendByte__(a)
-            val = self.H.__get_ack__() >> 4
-            if (verbose):
-                if val & 0x2:
-                    print(' NRF radio not found. Connect one to the add-on port')
-                elif val & 0x1:
-                    print(' Node probably dead/out of range. It failed to acknowledge')
-                return
-            return val
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_WRITEPAYLOAD)
+        numbytes = len(
+            data) | 0x80  # 0x80 implies transmit immediately. Otherwise it will simply load the TX FIFO ( used by ACK_payload)
+        if (args.get('rxmode', False)): numbytes |= 0x40
+        self.H.__sendByte__(numbytes)
+        self.H.__sendByte__(self.TX_PAYLOAD)
+        for a in data:
+            self.H.__sendByte__(a)
+        val = self.H.__get_ack__() >> 4
+        if (verbose):
+            if val & 0x2:
+                print(' NRF radio not found. Connect one to the add-on port')
+            elif val & 0x1:
+                print(' Node probably dead/out of range. It failed to acknowledge')
+            return
+        return val
 
     def I2C_scan(self):
         '''
@@ -1211,42 +1088,40 @@ class NRF24L01():
 
     def transaction(self, data, **args):
         st = time.time()
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_TRANSACTION)
-            self.H.__sendByte__(len(data))  # total Data bytes coming through
-            if 'listen' not in args: args['listen'] = True
-            if args.get('listen', False): data[0] |= 0x80  # You need this if hardware must wait for a reply
-            timeout = args.get('timeout', 200)
-            verbose = args.get('verbose', False)
-            self.H.__sendInt__(timeout)  # timeout.
-            for a in data:
-                self.H.__sendByte__(a)
 
-            # print ('dt send',time.time()-st,timeout,data[0]&0x80,data)
-            numbytes = self.H.__getByte__()
-            # print ('byte 1 in',time.time()-st)
-            if numbytes:
-                data = self.H.fd.read(numbytes)
-            else:
-                data = []
-            val = self.H.__get_ack__() >> 4
-            if (verbose):
-                if val & 0x1: print(time.time(), '%s Err. Node not found' % (hex(self.CURRENT_ADDRESS)))
-                if val & 0x2: print(time.time(),
-                                    '%s Err. NRF on-board transmitter not found' % (hex(self.CURRENT_ADDRESS)))
-                if val & 0x4 and args['listen']: print(time.time(),
-                                                       '%s Err. Node received command but did not reply' % (
-                                                           hex(self.CURRENT_ADDRESS)))
-            if val & 0x7:  # Something didn't go right.
-                self.flush()
-                self.sigs[self.CURRENT_ADDRESS] = self.sigs[self.CURRENT_ADDRESS] * 50 / 51.
-                return False
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_TRANSACTION)
+        self.H.__sendByte__(len(data))  # total Data bytes coming through
+        if 'listen' not in args: args['listen'] = True
+        if args.get('listen', False): data[0] |= 0x80  # You need this if hardware must wait for a reply
+        timeout = args.get('timeout', 200)
+        verbose = args.get('verbose', False)
+        self.H.__sendInt__(timeout)  # timeout.
+        for a in data:
+            self.H.__sendByte__(a)
 
-            self.sigs[self.CURRENT_ADDRESS] = (self.sigs[self.CURRENT_ADDRESS] * 50 + 1) / 51.
-            return [ord(a) for a in data]
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        # print ('dt send',time.time()-st,timeout,data[0]&0x80,data)
+        numbytes = self.H.__getByte__()
+        # print ('byte 1 in',time.time()-st)
+        if numbytes:
+            data = self.H.fd.read(numbytes)
+        else:
+            data = []
+        val = self.H.__get_ack__() >> 4
+        if (verbose):
+            if val & 0x1: print(time.time(), '%s Err. Node not found' % (hex(self.CURRENT_ADDRESS)))
+            if val & 0x2: print(time.time(),
+                                '%s Err. NRF on-board transmitter not found' % (hex(self.CURRENT_ADDRESS)))
+            if val & 0x4 and args['listen']: print(time.time(),
+                                                   '%s Err. Node received command but did not reply' % (
+                                                       hex(self.CURRENT_ADDRESS)))
+        if val & 0x7:  # Something didn't go right.
+            self.flush()
+            self.sigs[self.CURRENT_ADDRESS] = self.sigs[self.CURRENT_ADDRESS] * 50 / 51.
+            return False
+
+        self.sigs[self.CURRENT_ADDRESS] = (self.sigs[self.CURRENT_ADDRESS] * 50 + 1) / 51.
+        return [ord(a) for a in data]
 
     def transactionWithRetries(self, data, **args):
         retries = args.get('retries', 5)
@@ -1267,61 +1142,47 @@ class NRF24L01():
                 data = data[:15]
             else:
                 print('ack payload size:', self.ACK_PAYLOAD_SIZE)
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_WRITEPAYLOAD)
-            self.H.__sendByte__(len(data))
-            self.H.__sendByte__(self.ACK_PAYLOAD | pipe)
-            for a in data:
-                self.H.__sendByte__(a)
-            return self.H.__get_ack__() >> 4
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_WRITEPAYLOAD)
+        self.H.__sendByte__(len(data))
+        self.H.__sendByte__(self.ACK_PAYLOAD | pipe)
+        for a in data:
+            self.H.__sendByte__(a)
+        return self.H.__get_ack__() >> 4
 
     def start_token_manager(self):
         '''
         '''
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_START_TOKEN_MANAGER)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_START_TOKEN_MANAGER)
+        self.H.__get_ack__()
 
     def stop_token_manager(self):
         '''
         '''
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_STOP_TOKEN_MANAGER)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_STOP_TOKEN_MANAGER)
+        self.H.__get_ack__()
 
     def total_tokens(self):
         '''
         '''
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_TOTAL_TOKENS)
-            x = self.H.__getByte__()
-            self.H.__get_ack__()
-            return x
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_TOTAL_TOKENS)
+        x = self.H.__getByte__()
+        self.H.__get_ack__()
+        return x
 
     def fetch_report(self, num):
         '''
         '''
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_REPORTS)
-            self.H.__sendByte__(num)
-            data = [self.H.__getByte__() for a in range(20)]
-            self.H.__get_ack__()
-            return data
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_REPORTS)
+        self.H.__sendByte__(num)
+        data = [self.H.__getByte__() for a in range(20)]
+        self.H.__get_ack__()
+        return data
 
     def __decode_I2C_list__(self, data):
         lst = []
@@ -1366,13 +1227,10 @@ class NRF24L01():
         return filtered_lst
 
     def __delete_registered_node__(self, num):
-        try:
-            self.H.__sendByte__(CP.NRFL01)
-            self.H.__sendByte__(CP.NRF_DELETE_REPORT_ROW)
-            self.H.__sendByte__(num)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NRFL01)
+        self.H.__sendByte__(CP.NRF_DELETE_REPORT_ROW)
+        self.H.__sendByte__(num)
+        self.H.__get_ack__()
 
     def __delete_all_registered_nodes__(self):
         while self.total_tokens():

--- a/PSL/README.md
+++ b/PSL/README.md
@@ -6,7 +6,7 @@ Sciencelab class contains methods that can be used to interact with the FOSSASIA
 	>>> I = sciencelab.connect()
 	>>> self.__print__(I)
 	<sciencelab.ScienceLab instance at 0xb6c0cac>
-	
+
 Once you have initiated this class,  its various methods will allow access to all the features built into the device.
 
 <details>
@@ -29,7 +29,7 @@ Once you have initiated this class,  its various methods will allow access to al
 
 + Arguments
 	+ \*\*Kwargs: Keyword Arguments
-		+ address: Address of the node. a 24 bit number. Printed on the nodes. Can also be retrieved using :py:meth:`~NRF24L01_class.NRF24L01.get_nodelist` 
+		+ address: Address of the node. a 24 bit number. Printed on the nodes. Can also be retrieved using :py:meth:`~NRF24L01_class.NRF24L01.get_nodelist`
 + Return: :py:meth:`~NRF_NODE.RadioLink`
 
 </details>
@@ -53,7 +53,7 @@ This section has commands related to analog measurement and control. These inclu
 	+ ch: Channel to select as input. ['CH1'..'CH3','SEN']
 	+ ns: Number of samples to fetch. Maximum 10000
 	+ tg: Timegap between samples in microseconds
-+ Return: Arrays X(timestamps),Y(Corresponding Voltage values)	
++ Return: Arrays X(timestamps),Y(Corresponding Voltage values)
 
 ```
 >>> from pylab import *
@@ -147,7 +147,7 @@ This section has commands related to analog measurement and control. These inclu
 		+ 'SET_HIGH': Set SQR1 to 1V
 		+ 'FIRE_PULSES': output a preset frequency on SQR1 for a given interval (keyword arg 'interval' must be specified or it will default to 1000uS) before acquiring data. This is used for measuring speed of sound using piezos if no arguments are specified, a regular capture will be executed.
 	+ \*\*kwargs
-		+ interval: Units: uS. Necessary if 'FIRE_PULSES' argument was supplied. Default 1000uS  
+		+ interval: Units: uS. Necessary if 'FIRE_PULSES' argument was supplied. Default 1000uS
 + Return: timestamp array ,voltage_value array
 
 ```
@@ -185,7 +185,7 @@ This section has commands related to analog measurement and control. These inclu
 + Arguments
 	+ num: Channels to acquire. 1/2/4
 	+ samples: Total points to store per channel. Maximum 3200 total.
-	+ tg: Timegap between two successive samples (in uSec) 
+	+ tg: Timegap between two successive samples (in uSec)
 	+ channel_one_input: Map channel 1 to 'CH1' ... 'CH9'
 	+ \*\*kwargs
 		+ \*trigger: Whether or not to trigger the oscilloscope based on the voltage level set by :func:`configure_trigger`
@@ -345,7 +345,7 @@ The following events take place when the above snippet runs
 + Return the voltage on the selected channel
 + Arguments
 	+ channel_name : 'CH1','CH2','CH3', 'MIC','IN1','SEN','V+'
-	+ sleep: Read voltage in CPU sleep mode. not particularly useful. Also, Buggy. 
+	+ sleep: Read voltage in CPU sleep mode. not particularly useful. Also, Buggy.
 	+ \*\*kwargs: Samples to average can be specified. Eg, samples=100 will average a hundred readings
 
 ```
@@ -384,7 +384,7 @@ The following events take place when the above snippet runs
 + Instruct the ADC to start streaming 8-bit data.  use stop_streaming to stop.
 + Arguments
 	+ tg: timegap. 250KHz clock
-	+ channel: channel 'CH1'... 'CH9','IN1','SEN'  
+	+ channel: channel 'CH1'... 'CH9','IN1','SEN'
 
 </details>
 
@@ -583,7 +583,7 @@ Connect SQR1 to ID1
 	+ channel: ['ID1','ID2','ID3','ID4','SEN','EXT','CNTR']
 	+ maximum_time: Total time to sample. If total time exceeds 67 seconds, a prescaler will be used in the reference clock.
 	+ kwargs
-		+ triggger_channels: array of digital input names that can trigger the acquisition. Eg, trigger = ['ID1','ID2','ID3'] will triggger when a logic change specified by the keyword argument 'edge' occurs on either or the three specified trigger inputs. 
+		+ triggger_channels: array of digital input names that can trigger the acquisition. Eg, trigger = ['ID1','ID2','ID3'] will triggger when a logic change specified by the keyword argument 'edge' occurs on either or the three specified trigger inputs.
 		+ edge: 'rising' or 'falling' . trigger edge type for trigger_channels.
 + Return: Nothing
 
@@ -613,7 +613,7 @@ Connect SQR1 to ID1
 + Arguments
 	+ trigger: Bool. Enable rising edge trigger on ID1
 	+ \*\*args
-		+ chans: Channels to acquire data from . default ['ID1','ID2'] 
+		+ chans: Channels to acquire data from . default ['ID1','ID2']
 		+ mode: modes for each channel. Array, default value: [1,1]
 			+ EVERY_SIXTEENTH_RISING_EDGE = 5
 			+ EVERY_FOURTH_RISING_EDGE    = 4
@@ -632,7 +632,7 @@ Connect SQR1 to ID1
 + Start logging timestamps of rising/falling edges on ID1, ID2, ID3
 + Arguments
 	+ \*\*args
-		+ trigger_channel: ['ID1','ID2','ID3','ID4','SEN','EXT','CNTR'] 
+		+ trigger_channel: ['ID1','ID2','ID3','ID4','SEN','EXT','CNTR']
 		+ mode: modes for each channel. Array, default value: [1,1,1]
 			+ EVERY_SIXTEENTH_RISING_EDGE = 5
 			+ EVERY_FOURTH_RISING_EDGE    = 4
@@ -757,7 +757,7 @@ If you need to record large intervals, try single channel/two channel modes whic
 		states(0 or 1)
 ```
 >>> I.set_state(SQR1 = 1,SQR2 = 0)
-#Sets SQR1 HIGH, SQR2 LOw, but leave SQR3,SQR4 untouched.	
+#Sets SQR1 HIGH, SQR2 LOw, but leave SQR3,SQR4 untouched.
 ```
 
 </details>
@@ -811,17 +811,17 @@ If you need to record large intervals, try single channel/two channel modes whic
 <summary><code>get_ctmu_voltage(self, channel, Crange, tgen = 1)</code></summary>
 
 + get_ctmu_voltage(5,2)  will activate a constant current source of 5.5uA on IN1 and then measure the voltage at the output.
-+ If a diode is used to connect IN1 to ground, the forward voltage drop of the diode will be returned. e.g. .6V for a 4148diode.  
++ If a diode is used to connect IN1 to ground, the forward voltage drop of the diode will be returned. e.g. .6V for a 4148diode.
 + Returns: Voltage
 + Channel = 5 for IN1
 
-| CRange   |      Implies  | 
+| CRange   |      Implies  |
 |----------|:-------------:|
 | 0		   |  550uA		   |
 | 1		   |  0.55uA       |
 | 2		   | 5.5uA         |
 | 3		   | 55uA          |
-    
+
 </details>
 
 <details>
@@ -884,7 +884,7 @@ If you need to record large intervals, try single channel/two channel modes whic
 
 ## WAVEGEN SECTION
 
-This section has commands related to waveform generators W1, W2, PWM outputs, servo motor control etc. 
+This section has commands related to waveform generators W1, W2, PWM outputs, servo motor control etc.
 
 <details>
 <summary><code>set_wave(self, chan, freq)</code></summary>
@@ -1095,7 +1095,7 @@ This section has commands related to current and voltage sources PV1,PV2,PV3,PCS
 	+ val: Output voltage on PV1. -5V to 5V
 
 </details>
- 
+
 <details>
 <summary><code>set_pv2(self, val)</code></summary>
 
@@ -1148,20 +1148,20 @@ This section has commands related to current and voltage sources PV1,PV2,PV3,PCS
 + Get the last set voltage on PV3
 
 </details>
- 
+
 <details>
 <summary><code>get_pcs(self)</code></summary>
 
 + Get the last set voltage on PCS
 
 </details>
- 
+
 <details>
 <summary><code>WS2812B(self, cols, output = 'CS1')</code></summary>
 
 + Set shade of WS2182 LED on SQR1
 + Arguments
-	+ cols: 2Darray [[R,G,B],[R2,G2,B2],[R3,G3,B3]...] <br /> 
+	+ cols: 2Darray [[R,G,B],[R2,G2,B2],[R3,G3,B3]...] <br />
 			brightness of R,G,B ( 0-255  )
 
 ```
@@ -1182,20 +1182,20 @@ Direct access to RAM and FLASH
 	+ address: Address to read from. Refer to PIC24EP64GP204 programming manual
 
 </details>
- 
+
 <details>
 <summary><code>device_id(self)</code></summary><br />
 </details>
- 
+
 <details>
 <summary><code>read_data_address(self, address)</code></summary>
 
 + Reads and returns the value stored at the specified address in RAM
 + Arguments
-	+ address: Address to read from.  Refer to PIC24EP64GP204 programming manual 
+	+ address: Address to read from.  Refer to PIC24EP64GP204 programming manual
 
 </details>
- 
+
 ## MOTOR SIGNALLING
 Set servo motor angles via SQ1-4. Control one stepper motor using SQ1-4
 
@@ -1206,7 +1206,7 @@ Set servo motor angles via SQ1-4. Control one stepper motor using SQ1-4
 + Take a fixed number of steps in the forward direction with a certain delay( in milliseconds ) between each step.
 
 </details>
- 
+
 <details>
 <summary><code>stepBackward(self, steps, delay)</code></summary>
 
@@ -1214,7 +1214,7 @@ Set servo motor angles via SQ1-4. Control one stepper motor using SQ1-4
 + Take a fixed number of steps in the backward direction with a certain delay( in milliseconds ) between each step.
 
 </details>
- 
+
 <details>
 <summary><code>servo(self, angle, chan = 'SQR1')</code></summary>
 
@@ -1225,7 +1225,7 @@ Set servo motor angles via SQ1-4. Control one stepper motor using SQ1-4
 	+ chan: 'SQR1' or 'SQR2'. Whether to use SQ1 or SQ2 to output the PWM waveform used by the servo
 
 </details>
- 
+
 <details>
 <summary><code>servo4(self, a1, a2, a3, a4)</code></summary>
 
@@ -1239,7 +1239,7 @@ Set servo motor angles via SQ1-4. Control one stepper motor using SQ1-4
 	+ a4: Angle to set on Servo which uses SQR4 as PWM input. [0-180]
 
 </details>
- 
+
 <details>
 <summary><code>enableUartPassthrough(self, baudrate, persist = False)</code></summary>
 
@@ -1252,7 +1252,7 @@ Set servo motor angles via SQ1-4. Control one stepper motor using SQ1-4
 	Otherwise(default scenario), the device will return to normal operation if no data is sent/received for a period greater than one second at a time.
 
 </details>
- 
+
 <details>
 <summary><code>estimateDistance(self)</code></summary>
 
@@ -1264,7 +1264,7 @@ Set servo motor angles via SQ1-4. Control one stepper motor using SQ1-4
 + Return: 0 upon timeout
 
 </details>
- 
+
 <details>
 <summary><code>opticalArray(self, SS, delay, channel = 'CH3', **kwargs)</code></summary>
 
@@ -1274,33 +1274,29 @@ Set servo motor angles via SQ1-4. Control one stepper motor using SQ1-4
 + tp : clock wavelength = tp*15nS,  SS = clock/4
 
 </details>
- 
+
 <details>
 <summary><code>setUARTBAUD(self, BAUD)</code></summary><br />
 </details>
- 
+
 <details>
 <summary><code>writeUART(self, character)</code></summary><br />
 </details>
- 
+
 <details>
 <summary><code>readUART(self)</code></summary><br />
 </details>
- 
+
 <details>
 <summary><code>readUARTStatus(self)</code></summary>
 
 + Return: available bytes in UART buffer
 
 </details>
- 
+
 <details>
 <summary><code>readLog(self)</code></summary>
 
 + Read hardware debug log.
 
-</details>
- 
-<details>
-<summary><code>raiseException(self, ex, msg)</code></summary><br />
 </details>

--- a/PSL/packet_handler.py
+++ b/PSL/packet_handler.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 
 import time
 
-import inspect
 import serial
 
 import PSL.commands_proto as CP
@@ -24,23 +23,18 @@ class Handler():
         self.blockingSocket = None
         if 'port' in kwargs:
             self.portname = kwargs.get('port', None)
-            try:
-                self.fd, self.version_string, self.connected = self.connectToPort(self.portname)
-                if self.connected: return
-            except Exception as ex:
-                print('Failed to connect to ', self.portname, ex.message)
+            self.fd, self.version_string, self.connected = self.connectToPort(self.portname)
+            if self.connected: return
 
         else:  # Scan and pick a port
             L = self.listPorts()
             for a in L:
-                try:
-                    self.portname = a
-                    self.fd, self.version_string, self.connected = self.connectToPort(self.portname)
-                    if self.connected:
-                        print(a + ' .yes.', self.version_string)
-                        return
-                except:
-                    pass
+                self.portname = a
+                self.fd, self.version_string, self.connected = self.connectToPort(self.portname)
+                if self.connected:
+                    print(a + ' .yes.', self.version_string)
+                    return
+
             if not self.connected:
                 if len(self.occupiedPorts): print('Device not found. Programs already using :', self.occupiedPorts)
 
@@ -76,7 +70,7 @@ class Handler():
                 self.blockingSocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             except socket.error as e:
                 self.occupiedPorts.add(portname)
-                raise RuntimeError("Another program is using %s (%d)" % (portname))
+                raise e
 
         fd = serial.Serial(portname, 9600, stopbits=1, timeout=0.02)
         fd.read(100)
@@ -116,19 +110,11 @@ class Handler():
         if 'port' in kwargs:
             self.portname = kwargs.get('port', None)
 
-        try:
-            self.fd, self.version_string, self.connected = self.connectToPort(self.portname)
-        except serial.SerialException as ex:
-            msg = "failed to reconnect. Check device connections."
-            print(msg)
-            raise RuntimeError(msg)
+        self.fd, self.version_string, self.connected = self.connectToPort(self.portname)
 
     def __del__(self):
         # print('closing port')
-        try:
-            self.fd.close()
-        except:
-            pass
+        self.fd.close()
 
     def __get_ack__(self):
         """
@@ -180,13 +166,8 @@ class Handler():
         reads a byte from the serial port and returns it
         """
         ss = self.fd.read(1)
-        try:
-            if len(ss):
-                return CP.Byte.unpack(ss)[0]
-        except Exception as ex:
-            print('byte communication error.', time.ctime())
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
-            # sys.exit(1)
+        if len(ss):
+            return CP.Byte.unpack(ss)[0]
 
     def __getInt__(self):
         """
@@ -194,13 +175,8 @@ class Handler():
         returns an integer after combining them
         """
         ss = self.fd.read(2)
-        try:
-            if len(ss) == 2:
-                return CP.ShortInt.unpack(ss)[0]
-        except Exception as ex:
-            print('int communication error.', time.ctime())
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
-            # sys.exit(1)
+        if len(ss) == 2:
+            return CP.ShortInt.unpack(ss)[0]
 
     def __getLong__(self):
         """

--- a/PSL/sciencelab.py
+++ b/PSL/sciencelab.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
-# Communication Library for  Pocket Science Lab from FOSSASIA 
+# Communication Library for  Pocket Science Lab from FOSSASIA
 #
-# License : GNU GPL 
+# License : GNU GPL
 
 from __future__ import print_function
 
-import inspect
 import time
 
 import PSL.commands_proto as CP
@@ -101,19 +100,8 @@ class ScienceLab():
         self.aboutArray = []
         self.errmsg = ''
         # --------------------------Initialize communication handler, and subclasses-----------------
-        try:
-            self.H = packet_handler.Handler(**kwargs)
-        except Exception as ex:
-            self.errmsg = "failed to Connect. Please check connections/arguments\n" + ex.message
-            self.connected = False
-            print(self.errmsg)  # raise RuntimeError(msg)
-
-        try:
-            self.__runInitSequence__(**kwargs)
-        except Exception as ex:
-            self.errmsg = "failed to run init sequence. Check device connections\n" + str(ex)
-            self.connected = False
-            print(self.errmsg)  # raise RuntimeError(msg)
+        self.H = packet_handler.Handler(**kwargs)
+        self.__runInitSequence__(**kwargs)
 
     def __runInitSequence__(self, **kwargs):
         self.aboutArray = []
@@ -299,27 +287,17 @@ class ScienceLab():
             print()
 
     def __del__(self):
-        self.__print__('Closing PORT')
-        try:
-            self.H.fd.close()
-        except:
-            pass
+        self.H.fd.close()
 
     def get_version(self):
         """
 		Returns the version string of the device
 		format: LTS-......
 		"""
-        try:
-            return self.H.get_version(self.H.fd)
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        return self.H.get_version(self.H.fd)
 
     def getRadioLinks(self):
-        try:
-            return self.NRF.get_nodelist()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        return self.NRF.get_nodelist()
 
     def newRadioLink(self, **args):
         '''
@@ -340,10 +318,7 @@ class ScienceLab():
 
 		'''
         from PSL.Peripherals import RadioLink
-        try:
-            return RadioLink(self.NRF, **args)
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        return RadioLink(self.NRF, **args)
 
     # -------------------------------------------------------------------------------------------------------------------#
 
@@ -356,14 +331,8 @@ class ScienceLab():
         '''
 		Attempts to reconnect to the device in case of a commmunication error or accidental disconnect.
 		'''
-        try:
-            self.H.reconnect(**kwargs)
-            self.__runInitSequence__(**kwargs)
-        except Exception as ex:
-            self.errmsg = str(ex)
-            self.H.disconnect()
-            print(self.errmsg)
-            raise RuntimeError(self.errmsg)
+        self.H.reconnect(**kwargs)
+        self.__runInitSequence__(**kwargs)
 
     def capture1(self, ch, ns, tg, *args, **kwargs):
         """
@@ -437,17 +406,13 @@ class ScienceLab():
 		:return: Arrays X(timestamps),Y1(Voltage at CH1),Y2(Voltage at CH2)
 
 		"""
-        try:
-            self.capture_traces(2, ns, tg, TraceOneRemap)
-            time.sleep(1e-6 * self.samples * self.timebase + .01)
-            while not self.oscilloscope_progress()[0]:
-                pass
+        self.capture_traces(2, ns, tg, TraceOneRemap)
+        time.sleep(1e-6 * self.samples * self.timebase + .01)
+        while not self.oscilloscope_progress()[0]:
+            pass
 
-            self.__fetch_channel__(1)
-            self.__fetch_channel__(2)
-
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.__fetch_channel__(1)
+        self.__fetch_channel__(2)
 
         x = self.achans[0].get_xaxis()
         y = self.achans[0].get_yaxis()
@@ -491,17 +456,14 @@ class ScienceLab():
 		:return: Arrays X(timestamps),Y1(Voltage at CH1),Y2(Voltage at CH2),Y3(Voltage at CH3),Y4(Voltage at CH4)
 
 		"""
-        try:
-            self.capture_traces(4, ns, tg, TraceOneRemap)
-            time.sleep(1e-6 * self.samples * self.timebase + .01)
-            while not self.oscilloscope_progress()[0]:
-                pass
-            x, y = self.fetch_trace(1)
-            x, y2 = self.fetch_trace(2)
-            x, y3 = self.fetch_trace(3)
-            x, y4 = self.fetch_trace(4)
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.capture_traces(4, ns, tg, TraceOneRemap)
+        time.sleep(1e-6 * self.samples * self.timebase + .01)
+        while not self.oscilloscope_progress()[0]:
+            pass
+        x, y = self.fetch_trace(1)
+        x, y2 = self.fetch_trace(2)
+        x, y3 = self.fetch_trace(3)
+        x, y4 = self.fetch_trace(4)
 
         return x, y, y2, y3, y4
 
@@ -553,45 +515,42 @@ class ScienceLab():
             CHANNEL_SELECTION |= (1 << C)
         self.__print__('selection', CHANNEL_SELECTION, len(args), hex(CHANNEL_SELECTION | ((total_chans - 1) << 12)))
 
-        try:
+        self.H.__sendByte__(CP.ADC)
+        self.H.__sendByte__(CP.CAPTURE_MULTIPLE)
+        self.H.__sendInt__(CHANNEL_SELECTION | ((total_chans - 1) << 12))
+
+        self.H.__sendInt__(total_samples)  # total number of samples to record
+        self.H.__sendInt__(int(self.timebase * 8))  # Timegap between samples.  8MHz timer clock
+        self.H.__get_ack__()
+        self.__print__('wait')
+        time.sleep(1e-6 * total_samples * tg + .01)
+        self.__print__('done')
+        data = b''
+        for i in range(int(total_samples / self.data_splitting)):
             self.H.__sendByte__(CP.ADC)
-            self.H.__sendByte__(CP.CAPTURE_MULTIPLE)
-            self.H.__sendInt__(CHANNEL_SELECTION | ((total_chans - 1) << 12))
-
-            self.H.__sendInt__(total_samples)  # total number of samples to record
-            self.H.__sendInt__(int(self.timebase * 8))  # Timegap between samples.  8MHz timer clock
+            self.H.__sendByte__(CP.GET_CAPTURE_CHANNEL)
+            self.H.__sendByte__(0)  # channel number . starts with A0 on PIC
+            self.H.__sendInt__(self.data_splitting)
+            self.H.__sendInt__(i * self.data_splitting)
+            data += self.H.fd.read(int(
+                self.data_splitting * 2))  # reading int by int sometimes causes a communication error. this works better.
             self.H.__get_ack__()
-            self.__print__('wait')
-            time.sleep(1e-6 * total_samples * tg + .01)
-            self.__print__('done')
-            data = b''
-            for i in range(int(total_samples / self.data_splitting)):
-                self.H.__sendByte__(CP.ADC)
-                self.H.__sendByte__(CP.GET_CAPTURE_CHANNEL)
-                self.H.__sendByte__(0)  # channel number . starts with A0 on PIC
-                self.H.__sendInt__(self.data_splitting)
-                self.H.__sendInt__(i * self.data_splitting)
-                data += self.H.fd.read(int(
-                    self.data_splitting * 2))  # reading int by int sometimes causes a communication error. this works better.
-                self.H.__get_ack__()
 
-            if total_samples % self.data_splitting:
-                self.H.__sendByte__(CP.ADC)
-                self.H.__sendByte__(CP.GET_CAPTURE_CHANNEL)
-                self.H.__sendByte__(0)  # channel number starts with A0 on PIC
-                self.H.__sendInt__(total_samples % self.data_splitting)
-                self.H.__sendInt__(total_samples - total_samples % self.data_splitting)
-                data += self.H.fd.read(int(2 * (
-                        total_samples % self.data_splitting)))  # reading int by int may cause packets to be dropped. this works better.
-                self.H.__get_ack__()
+        if total_samples % self.data_splitting:
+            self.H.__sendByte__(CP.ADC)
+            self.H.__sendByte__(CP.GET_CAPTURE_CHANNEL)
+            self.H.__sendByte__(0)  # channel number starts with A0 on PIC
+            self.H.__sendInt__(total_samples % self.data_splitting)
+            self.H.__sendInt__(total_samples - total_samples % self.data_splitting)
+            data += self.H.fd.read(int(2 * (
+                    total_samples % self.data_splitting)))  # reading int by int may cause packets to be dropped. this works better.
+            self.H.__get_ack__()
 
-            for a in range(int(total_samples)): self.buff[a] = CP.ShortInt.unpack(data[a * 2:a * 2 + 2])[0]
-            # self.achans[channel_number-1].yaxis = self.achans[channel_number-1].fix_value(self.buff[:samples])
-            yield np.linspace(0, tg * (samples - 1), samples)
-            for a in range(int(total_chans)):
-                yield self.buff[a:total_samples][::total_chans]
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        for a in range(int(total_samples)): self.buff[a] = CP.ShortInt.unpack(data[a * 2:a * 2 + 2])[0]
+        # self.achans[channel_number-1].yaxis = self.achans[channel_number-1].fix_value(self.buff[:samples])
+        yield np.linspace(0, tg * (samples - 1), samples)
+        for a in range(int(total_chans)):
+            yield self.buff[a:total_samples][::total_chans]
 
     def __capture_fullspeed__(self, chan, samples, tg, *args, **kwargs):
         tg = int(tg * 8) / 8.  # Round off the timescale to 1/8uS units
@@ -604,29 +563,26 @@ class ScienceLab():
         self.samples = samples
         CHOSA = self.analogInputSources[chan].CHOSA
 
-        try:
-            self.H.__sendByte__(CP.ADC)
-            if 'SET_LOW' in args:
-                self.H.__sendByte__(CP.SET_LO_CAPTURE)
-            elif 'SET_HIGH' in args:
-                self.H.__sendByte__(CP.SET_HI_CAPTURE)
-            elif 'FIRE_PULSES' in args:
-                self.H.__sendByte__(CP.PULSE_TRAIN)
-                self.__print__('firing sqr1 pulses for ', kwargs.get('interval', 1000), 'uS')
-            else:
-                self.H.__sendByte__(CP.CAPTURE_DMASPEED)
-            self.H.__sendByte__(CHOSA)
-            self.H.__sendInt__(samples)  # total number of samples to record
-            self.H.__sendInt__(int(tg * 8))  # Timegap between samples.  8MHz timer clock
-            if 'FIRE_PULSES' in args:
-                t = kwargs.get('interval', 1000)
-                print('Firing for', t, 'uS')
-                self.H.__sendInt__(t)
-                time.sleep(
-                    t * 1e-6)  # Wait for hardware to free up from firing pulses(blocking call). Background capture starts immediately after this
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.ADC)
+        if 'SET_LOW' in args:
+            self.H.__sendByte__(CP.SET_LO_CAPTURE)
+        elif 'SET_HIGH' in args:
+            self.H.__sendByte__(CP.SET_HI_CAPTURE)
+        elif 'FIRE_PULSES' in args:
+            self.H.__sendByte__(CP.PULSE_TRAIN)
+            self.__print__('firing sqr1 pulses for ', kwargs.get('interval', 1000), 'uS')
+        else:
+            self.H.__sendByte__(CP.CAPTURE_DMASPEED)
+        self.H.__sendByte__(CHOSA)
+        self.H.__sendInt__(samples)  # total number of samples to record
+        self.H.__sendInt__(int(tg * 8))  # Timegap between samples.  8MHz timer clock
+        if 'FIRE_PULSES' in args:
+            t = kwargs.get('interval', 1000)
+            print('Firing for', t, 'uS')
+            self.H.__sendInt__(t)
+            time.sleep(
+                t * 1e-6)  # Wait for hardware to free up from firing pulses(blocking call). Background capture starts immediately after this
+        self.H.__get_ack__()
 
     def capture_fullspeed(self, chan, samples, tg, *args, **kwargs):
         """
@@ -692,30 +648,24 @@ class ScienceLab():
         self.timebase = int(tg * 8) / 8.
         self.samples = samples
         CHOSA = self.analogInputSources[chan].CHOSA
-        try:
-            self.H.__sendByte__(CP.ADC)
-            if 'SET_LOW' in args:
-                self.H.__sendByte__(CP.SET_LO_CAPTURE)
-            elif 'SET_HIGH' in args:
-                self.H.__sendByte__(CP.SET_HI_CAPTURE)
-            elif 'READ_CAP' in args:
-                self.H.__sendByte__(CP.MULTIPOINT_CAPACITANCE)
-            else:
-                self.H.__sendByte__(CP.CAPTURE_DMASPEED)
-            self.H.__sendByte__(CHOSA | 0x80)
-            self.H.__sendInt__(samples)  # total number of samples to record
-            self.H.__sendInt__(int(tg * 8))  # Timegap between samples.  8MHz timer clock
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.ADC)
+        if 'SET_LOW' in args:
+            self.H.__sendByte__(CP.SET_LO_CAPTURE)
+        elif 'SET_HIGH' in args:
+            self.H.__sendByte__(CP.SET_HI_CAPTURE)
+        elif 'READ_CAP' in args:
+            self.H.__sendByte__(CP.MULTIPOINT_CAPACITANCE)
+        else:
+            self.H.__sendByte__(CP.CAPTURE_DMASPEED)
+        self.H.__sendByte__(CHOSA | 0x80)
+        self.H.__sendInt__(samples)  # total number of samples to record
+        self.H.__sendInt__(int(tg * 8))  # Timegap between samples.  8MHz timer clock
+        self.H.__get_ack__()
 
     def capture_fullspeed_hr(self, chan, samples, tg, *args):
-        try:
-            self.__capture_fullspeed_hr__(chan, samples, tg, *args)
-            time.sleep(1e-6 * self.samples * self.timebase + .01)
-            x, y = self.__retrieveBufferData__(chan, self.samples, self.timebase)
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.__capture_fullspeed_hr__(chan, samples, tg, *args)
+        time.sleep(1e-6 * self.samples * self.timebase + .01)
+        x, y = self.__retrieveBufferData__(chan, self.samples, self.timebase)
 
         return x, self.analogInputSources[chan].calPoly12(y)
 
@@ -724,34 +674,27 @@ class ScienceLab():
 
 		'''
         data = b''
-        try:
-            for i in range(int(samples / self.data_splitting)):
-                self.H.__sendByte__(CP.ADC)
-                self.H.__sendByte__(CP.GET_CAPTURE_CHANNEL)
-                self.H.__sendByte__(0)  # channel number . starts with A0 on PIC
-                self.H.__sendInt__(self.data_splitting)
-                self.H.__sendInt__(i * self.data_splitting)
-                data += self.H.fd.read(int(
-                    self.data_splitting * 2))  # reading int by int sometimes causes a communication error. this works better.
-                self.H.__get_ack__()
+        for i in range(int(samples / self.data_splitting)):
+            self.H.__sendByte__(CP.ADC)
+            self.H.__sendByte__(CP.GET_CAPTURE_CHANNEL)
+            self.H.__sendByte__(0)  # channel number . starts with A0 on PIC
+            self.H.__sendInt__(self.data_splitting)
+            self.H.__sendInt__(i * self.data_splitting)
+            data += self.H.fd.read(int(
+                self.data_splitting * 2))  # reading int by int sometimes causes a communication error. this works better.
+            self.H.__get_ack__()
 
-            if samples % self.data_splitting:
-                self.H.__sendByte__(CP.ADC)
-                self.H.__sendByte__(CP.GET_CAPTURE_CHANNEL)
-                self.H.__sendByte__(0)  # channel number starts with A0 on PIC
-                self.H.__sendInt__(samples % self.data_splitting)
-                self.H.__sendInt__(samples - samples % self.data_splitting)
-                data += self.H.fd.read(int(2 * (
-                        samples % self.data_splitting)))  # reading int by int may cause packets to be dropped. this works better.
-                self.H.__get_ack__()
+        if samples % self.data_splitting:
+            self.H.__sendByte__(CP.ADC)
+            self.H.__sendByte__(CP.GET_CAPTURE_CHANNEL)
+            self.H.__sendByte__(0)  # channel number starts with A0 on PIC
+            self.H.__sendInt__(samples % self.data_splitting)
+            self.H.__sendInt__(samples - samples % self.data_splitting)
+            data += self.H.fd.read(int(2 * (
+                    samples % self.data_splitting)))  # reading int by int may cause packets to be dropped. this works better.
+            self.H.__get_ack__()
 
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
-        try:
-            for a in range(int(samples)): self.buff[a] = CP.ShortInt.unpack(data[a * 2:a * 2 + 2])[0]
-        except Exception as ex:
-            msg = "Incorrect Number of Bytes Received\n"
-            raise RuntimeError(msg)
+        for a in range(int(samples)): self.buff[a] = CP.ShortInt.unpack(data[a * 2:a * 2 + 2])[0]
 
         # self.achans[channel_number-1].yaxis = self.achans[channel_number-1].fix_value(self.buff[:samples])
         return np.linspace(0, tg * (samples - 1), samples), self.buff[:samples]
@@ -833,51 +776,48 @@ class ScienceLab():
         if channel_one_input not in self.analogInputSources: raise RuntimeError(
             'Invalid input %s, not in %s' % (channel_one_input, str(self.analogInputSources.keys())))
         CHOSA = self.analogInputSources[channel_one_input].CHOSA
-        try:
-            self.H.__sendByte__(CP.ADC)
-            if (num == 1):
-                if (self.timebase < 1.5): self.timebase = int(1.5 * 8) / 8.
-                if (samples > self.MAX_SAMPLES): samples = self.MAX_SAMPLES
+        self.H.__sendByte__(CP.ADC)
+        if (num == 1):
+            if (self.timebase < 1.5): self.timebase = int(1.5 * 8) / 8.
+            if (samples > self.MAX_SAMPLES): samples = self.MAX_SAMPLES
 
-                self.achans[0].set_params(channel=channel_one_input, length=samples, timebase=self.timebase,
-                                          resolution=10, source=self.analogInputSources[channel_one_input])
-                self.H.__sendByte__(CP.CAPTURE_ONE)  # read 1 channel
-                self.H.__sendByte__(CHOSA | triggerornot)  # channelk number
+            self.achans[0].set_params(channel=channel_one_input, length=samples, timebase=self.timebase,
+                                      resolution=10, source=self.analogInputSources[channel_one_input])
+            self.H.__sendByte__(CP.CAPTURE_ONE)  # read 1 channel
+            self.H.__sendByte__(CHOSA | triggerornot)  # channelk number
 
-            elif (num == 2):
-                if (self.timebase < 1.75): self.timebase = int(1.75 * 8) / 8.
-                if (samples > self.MAX_SAMPLES / 2): samples = self.MAX_SAMPLES / 2
+        elif (num == 2):
+            if (self.timebase < 1.75): self.timebase = int(1.75 * 8) / 8.
+            if (samples > self.MAX_SAMPLES / 2): samples = self.MAX_SAMPLES / 2
 
-                self.achans[0].set_params(channel=channel_one_input, length=samples, timebase=self.timebase,
-                                          resolution=10, source=self.analogInputSources[channel_one_input])
-                self.achans[1].set_params(channel='CH2', length=samples, timebase=self.timebase, resolution=10,
-                                          source=self.analogInputSources['CH2'])
+            self.achans[0].set_params(channel=channel_one_input, length=samples, timebase=self.timebase,
+                                      resolution=10, source=self.analogInputSources[channel_one_input])
+            self.achans[1].set_params(channel='CH2', length=samples, timebase=self.timebase, resolution=10,
+                                      source=self.analogInputSources['CH2'])
 
-                self.H.__sendByte__(CP.CAPTURE_TWO)  # capture 2 channels
-                self.H.__sendByte__(CHOSA | triggerornot)  # channel 0 number
+            self.H.__sendByte__(CP.CAPTURE_TWO)  # capture 2 channels
+            self.H.__sendByte__(CHOSA | triggerornot)  # channel 0 number
 
-            elif (num == 3 or num == 4):
-                if (self.timebase < 1.75): self.timebase = int(1.75 * 8) / 8.
-                if (samples > self.MAX_SAMPLES / 4): samples = self.MAX_SAMPLES / 4
+        elif (num == 3 or num == 4):
+            if (self.timebase < 1.75): self.timebase = int(1.75 * 8) / 8.
+            if (samples > self.MAX_SAMPLES / 4): samples = self.MAX_SAMPLES / 4
 
-                self.achans[0].set_params(channel=channel_one_input, length=samples, timebase=self.timebase, \
-                                          resolution=10, source=self.analogInputSources[channel_one_input])
+            self.achans[0].set_params(channel=channel_one_input, length=samples, timebase=self.timebase, \
+                                      resolution=10, source=self.analogInputSources[channel_one_input])
 
-                for a in range(1, 4):
-                    chans = ['NONE', 'CH2', 'CH3', 'MIC']
-                    self.achans[a].set_params(channel=chans[a], length=samples, timebase=self.timebase, \
-                                              resolution=10, source=self.analogInputSources[chans[a]])
+            for a in range(1, 4):
+                chans = ['NONE', 'CH2', 'CH3', 'MIC']
+                self.achans[a].set_params(channel=chans[a], length=samples, timebase=self.timebase, \
+                                          resolution=10, source=self.analogInputSources[chans[a]])
 
-                self.H.__sendByte__(CP.CAPTURE_FOUR)  # read 4 channels
-                self.H.__sendByte__(CHOSA | (CH123SA << 4) | triggerornot)  # channel number
+            self.H.__sendByte__(CP.CAPTURE_FOUR)  # read 4 channels
+            self.H.__sendByte__(CHOSA | (CH123SA << 4) | triggerornot)  # channel number
 
-            self.samples = samples
-            self.H.__sendInt__(samples)  # number of samples per channel to record
-            self.H.__sendInt__(int(self.timebase * 8))  # Timegap between samples.  8MHz timer clock
-            self.H.__get_ack__()
-            self.channels_in_buffer = num
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.samples = samples
+        self.H.__sendInt__(samples)  # number of samples per channel to record
+        self.H.__sendInt__(int(self.timebase * 8))  # Timegap between samples.  8MHz timer clock
+        self.H.__get_ack__()
+        self.channels_in_buffer = num
 
     def capture_highres_traces(self, channel, samples, tg, **kwargs):
         """
@@ -906,24 +846,21 @@ class ScienceLab():
 		"""
         triggerornot = 0x80 if kwargs.get('trigger', True) else 0
         self.timebase = tg
-        try:
-            self.H.__sendByte__(CP.ADC)
-            CHOSA = self.analogInputSources[channel].CHOSA
-            if (self.timebase < 3): self.timebase = 3
-            if (samples > self.MAX_SAMPLES): samples = self.MAX_SAMPLES
-            self.achans[0].set_params(channel=channel, length=samples, timebase=self.timebase, resolution=12,
-                                      source=self.analogInputSources[channel])
+        self.H.__sendByte__(CP.ADC)
+        CHOSA = self.analogInputSources[channel].CHOSA
+        if (self.timebase < 3): self.timebase = 3
+        if (samples > self.MAX_SAMPLES): samples = self.MAX_SAMPLES
+        self.achans[0].set_params(channel=channel, length=samples, timebase=self.timebase, resolution=12,
+                                  source=self.analogInputSources[channel])
 
-            self.H.__sendByte__(CP.CAPTURE_12BIT)  # read 1 channel
-            self.H.__sendByte__(CHOSA | triggerornot)  # channelk number
+        self.H.__sendByte__(CP.CAPTURE_12BIT)  # read 1 channel
+        self.H.__sendByte__(CHOSA | triggerornot)  # channelk number
 
-            self.samples = samples
-            self.H.__sendInt__(samples)  # number of samples to read
-            self.H.__sendInt__(int(self.timebase * 8))  # Timegap between samples.  8MHz timer clock
-            self.H.__get_ack__()
-            self.channels_in_buffer = 1
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.samples = samples
+        self.H.__sendInt__(samples)  # number of samples to read
+        self.H.__sendInt__(int(self.timebase * 8))  # Timegap between samples.  8MHz timer clock
+        self.H.__get_ack__()
+        self.channels_in_buffer = 1
 
     def fetch_trace(self, channel_number):
         """
@@ -967,14 +904,12 @@ class ScienceLab():
 		"""
         conversion_done = 0
         samples = 0
-        try:
-            self.H.__sendByte__(CP.ADC)
-            self.H.__sendByte__(CP.GET_CAPTURE_STATUS)
-            conversion_done = self.H.__getByte__()
-            samples = self.H.__getInt__()
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.ADC)
+        self.H.__sendByte__(CP.GET_CAPTURE_STATUS)
+        conversion_done = self.H.__getByte__()
+        samples = self.H.__getInt__()
+        self.H.__get_ack__()
+
         return conversion_done, samples
 
     def __fetch_channel__(self, channel_number):
@@ -996,35 +931,28 @@ class ScienceLab():
             self.__print__('Channel unavailable')
             return False
         data = b''
-        try:
-            for i in range(int(samples / self.data_splitting)):
-                self.H.__sendByte__(CP.ADC)
-                self.H.__sendByte__(CP.GET_CAPTURE_CHANNEL)
-                self.H.__sendByte__(channel_number - 1)  # starts with A0 on PIC
-                self.H.__sendInt__(self.data_splitting)
-                self.H.__sendInt__(i * self.data_splitting)
-                data += self.H.fd.read(
-                    int(self.data_splitting * 2))  # reading int by int sometimes causes a communication error.
-                self.H.__get_ack__()
+        for i in range(int(samples / self.data_splitting)):
+            self.H.__sendByte__(CP.ADC)
+            self.H.__sendByte__(CP.GET_CAPTURE_CHANNEL)
+            self.H.__sendByte__(channel_number - 1)  # starts with A0 on PIC
+            self.H.__sendInt__(self.data_splitting)
+            self.H.__sendInt__(i * self.data_splitting)
+            data += self.H.fd.read(
+                int(self.data_splitting * 2))  # reading int by int sometimes causes a communication error.
+            self.H.__get_ack__()
 
-            if samples % self.data_splitting:
-                self.H.__sendByte__(CP.ADC)
-                self.H.__sendByte__(CP.GET_CAPTURE_CHANNEL)
-                self.H.__sendByte__(channel_number - 1)  # starts with A0 on PIC
-                self.H.__sendInt__(samples % self.data_splitting)
-                self.H.__sendInt__(samples - samples % self.data_splitting)
-                data += self.H.fd.read(
-                    int(2 * (samples % self.data_splitting)))  # reading int by int may cause packets to be dropped.
-                self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        if samples % self.data_splitting:
+            self.H.__sendByte__(CP.ADC)
+            self.H.__sendByte__(CP.GET_CAPTURE_CHANNEL)
+            self.H.__sendByte__(channel_number - 1)  # starts with A0 on PIC
+            self.H.__sendInt__(samples % self.data_splitting)
+            self.H.__sendInt__(samples - samples % self.data_splitting)
+            data += self.H.fd.read(
+                int(2 * (samples % self.data_splitting)))  # reading int by int may cause packets to be dropped.
+            self.H.__get_ack__()
 
-        try:
-            for a in range(int(samples)): self.buff[a] = CP.ShortInt.unpack(data[a * 2:a * 2 + 2])[0]
-            self.achans[channel_number - 1].yaxis = self.achans[channel_number - 1].fix_value(self.buff[:int(samples)])
-        except Exception as ex:
-            msg = "Incorrect Number of bytes received.\n"
-            raise RuntimeError(msg)
+        for a in range(int(samples)): self.buff[a] = CP.ShortInt.unpack(data[a * 2:a * 2 + 2])[0]
+        self.achans[channel_number - 1].yaxis = self.achans[channel_number - 1].fix_value(self.buff[:int(samples)])
 
         return True
 
@@ -1046,19 +974,16 @@ class ScienceLab():
         if (channel_number > self.channels_in_buffer):
             self.__print__('Channel unavailable')
             return False
-        try:
-            self.H.__sendByte__(CP.ADC)
-            self.H.__sendByte__(CP.GET_CAPTURE_CHANNEL)
-            self.H.__sendByte__(channel_number - 1)  # starts with A0 on PIC
-            self.H.__sendInt__(samples)
-            self.H.__sendInt__(offset)
-            data = self.H.fd.read(
-                int(samples * 2))  # reading int by int sometimes causes a communication error. this works better.
-            self.H.__get_ack__()
-            for a in range(int(samples)): self.buff[a] = CP.ShortInt.unpack(data[a * 2:a * 2 + 2])[0]
-            self.achans[channel_number - 1].yaxis = self.achans[channel_number - 1].fix_value(self.buff[:samples])
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.ADC)
+        self.H.__sendByte__(CP.GET_CAPTURE_CHANNEL)
+        self.H.__sendByte__(channel_number - 1)  # starts with A0 on PIC
+        self.H.__sendInt__(samples)
+        self.H.__sendInt__(offset)
+        data = self.H.fd.read(
+            int(samples * 2))  # reading int by int sometimes causes a communication error. this works better.
+        self.H.__get_ack__()
+        for a in range(int(samples)): self.buff[a] = CP.ShortInt.unpack(data[a * 2:a * 2 + 2])[0]
+        self.achans[channel_number - 1].yaxis = self.achans[channel_number - 1].fix_value(self.buff[:samples])
 
         return True
 
@@ -1096,28 +1021,25 @@ class ScienceLab():
 
 		"""
         prescaler = kwargs.get('prescaler', 0)
-        try:
-            self.H.__sendByte__(CP.ADC)
-            self.H.__sendByte__(CP.CONFIGURE_TRIGGER)
-            self.H.__sendByte__(
-                (prescaler << 4) | (1 << chan))  # Trigger channel (4lsb) , trigger timeout prescaler (4msb)
+        self.H.__sendByte__(CP.ADC)
+        self.H.__sendByte__(CP.CONFIGURE_TRIGGER)
+        self.H.__sendByte__(
+            (prescaler << 4) | (1 << chan))  # Trigger channel (4lsb) , trigger timeout prescaler (4msb)
 
-            if resolution == 12:
-                level = self.analogInputSources[name].voltToCode12(voltage)
-                level = np.clip(level, 0, 4095)
-            else:
-                level = self.analogInputSources[name].voltToCode10(voltage)
-                level = np.clip(level, 0, 1023)
+        if resolution == 12:
+            level = self.analogInputSources[name].voltToCode12(voltage)
+            level = np.clip(level, 0, 4095)
+        else:
+            level = self.analogInputSources[name].voltToCode10(voltage)
+            level = np.clip(level, 0, 1023)
 
-            if level > (2 ** resolution - 1):
-                level = (2 ** resolution - 1)
-            elif level < 0:
-                level = 0
+        if level > (2 ** resolution - 1):
+            level = (2 ** resolution - 1)
+        elif level < 0:
+            level = 0
 
-            self.H.__sendInt__(int(level))  # Trigger
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendInt__(int(level))  # Trigger
+        self.H.__get_ack__()
 
     def set_gain(self, channel, gain, Force=False):
         """
@@ -1158,17 +1080,14 @@ class ScienceLab():
             time.sleep(0.01)
             refresh = True
         if refresh or Force:
-            try:
-                self.analogInputSources[channel].setGain(self.gain_values[gain])
-                if gain > 7: gain = 0  # external attenuator mode. set gain 1x
-                self.H.__sendByte__(CP.ADC)
-                self.H.__sendByte__(CP.SET_PGA_GAIN)
-                self.H.__sendByte__(self.analogInputSources[channel].gainPGA)  # send the channel. SPI, not multiplexer
-                self.H.__sendByte__(gain)  # send the gain
-                self.H.__get_ack__()
-                return self.gain_values[gain]
-            except Exception as ex:
-                self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+            self.analogInputSources[channel].setGain(self.gain_values[gain])
+            if gain > 7: gain = 0  # external attenuator mode. set gain 1x
+            self.H.__sendByte__(CP.ADC)
+            self.H.__sendByte__(CP.SET_PGA_GAIN)
+            self.H.__sendByte__(self.analogInputSources[channel].gainPGA)  # send the channel. SPI, not multiplexer
+            self.H.__sendByte__(gain)  # send the gain
+            self.H.__get_ack__()
+            return self.gain_values[gain]
 
         return refresh
 
@@ -1262,11 +1181,7 @@ class ScienceLab():
 		1.002
 
 		"""
-        try:
-            poly = self.analogInputSources[channel_name].calPoly12
-        except Exception as ex:
-            msg = "Invalid Channel" + str(ex)
-            raise RuntimeError(msg)
+        poly = self.analogInputSources[channel_name].calPoly12
         vals = [self.__get_raw_average_voltage__(channel_name, **kwargs) for a in range(int(kwargs.get('samples', 1)))]
         # if vals[0]>2052:print (vals)
         val = np.average([poly(a) for a in vals])
@@ -1286,58 +1201,46 @@ class ScienceLab():
 		==============  ============================================================================================================
 
 		"""
-        try:
-            chosa = self.__calcCHOSA__(channel_name)
-            self.H.__sendByte__(CP.ADC)
-            self.H.__sendByte__(CP.GET_VOLTAGE_SUMMED)
-            self.H.__sendByte__(chosa)
-            V_sum = self.H.__getInt__()
-            self.H.__get_ack__()
-            return V_sum / 16.  # sum(V)/16.0  #
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        chosa = self.__calcCHOSA__(channel_name)
+        self.H.__sendByte__(CP.ADC)
+        self.H.__sendByte__(CP.GET_VOLTAGE_SUMMED)
+        self.H.__sendByte__(chosa)
+        V_sum = self.H.__getInt__()
+        self.H.__get_ack__()
+        return V_sum / 16.  # sum(V)/16.0  #
 
     def fetch_buffer(self, starting_position=0, total_points=100):
         """
 		fetches a section of the ADC hardware buffer
 		"""
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.RETRIEVE_BUFFER)
-            self.H.__sendInt__(starting_position)
-            self.H.__sendInt__(total_points)
-            for a in range(int(total_points)): self.buff[a] = self.H.__getInt__()
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.RETRIEVE_BUFFER)
+        self.H.__sendInt__(starting_position)
+        self.H.__sendInt__(total_points)
+        for a in range(int(total_points)): self.buff[a] = self.H.__getInt__()
+        self.H.__get_ack__()
 
     def clear_buffer(self, starting_position, total_points):
         """
 		clears a section of the ADC hardware buffer
 		"""
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.CLEAR_BUFFER)
-            self.H.__sendInt__(starting_position)
-            self.H.__sendInt__(total_points)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.CLEAR_BUFFER)
+        self.H.__sendInt__(starting_position)
+        self.H.__sendInt__(total_points)
+        self.H.__get_ack__()
 
     def fill_buffer(self, starting_position, point_array):
         """
 		fill a section of the ADC hardware buffer with data
 		"""
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.FILL_BUFFER)
-            self.H.__sendInt__(starting_position)
-            self.H.__sendInt__(len(point_array))
-            for a in point_array:
-                self.H.__sendInt__(int(a))
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.FILL_BUFFER)
+        self.H.__sendInt__(starting_position)
+        self.H.__sendInt__(len(point_array))
+        for a in point_array:
+            self.H.__sendInt__(int(a))
+        self.H.__get_ack__()
 
     def start_streaming(self, tg, channel='CH1'):
         """
@@ -1354,14 +1257,11 @@ class ScienceLab():
 
 		"""
         if (self.streaming): self.stop_streaming()
-        try:
-            self.H.__sendByte__(CP.ADC)
-            self.H.__sendByte__(CP.START_ADC_STREAMING)
-            self.H.__sendByte__(self.__calcCHOSA__(channel))
-            self.H.__sendInt__(tg)  # Timegap between samples.  8MHz timer clock
-            self.streaming = True
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.ADC)
+        self.H.__sendByte__(CP.START_ADC_STREAMING)
+        self.H.__sendByte__(self.__calcCHOSA__(channel))
+        self.H.__sendInt__(tg)  # Timegap between samples.  8MHz timer clock
+        self.streaming = True
 
     def stop_streaming(self):
         """
@@ -1395,16 +1295,13 @@ class ScienceLab():
             return 0
 
     def __get_high_freq__backup__(self, pin):
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.GET_HIGH_FREQUENCY)
-            self.H.__sendByte__(self.__calcDChan__(pin))
-            scale = self.H.__getByte__()
-            val = self.H.__getLong__()
-            self.H.__get_ack__()
-            return scale * (val) / 1.0e-1  # 100mS sampling
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.GET_HIGH_FREQUENCY)
+        self.H.__sendByte__(self.__calcDChan__(pin))
+        scale = self.H.__getByte__()
+        val = self.H.__getLong__()
+        self.H.__get_ack__()
+        return scale * (val) / 1.0e-1  # 100mS sampling
 
     def get_high_freq(self, pin):
         """
@@ -1430,17 +1327,14 @@ class ScienceLab():
 
 		:return: frequency
 		"""
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.GET_ALTERNATE_HIGH_FREQUENCY)
-            self.H.__sendByte__(self.__calcDChan__(pin))
-            scale = self.H.__getByte__()
-            val = self.H.__getLong__()
-            self.H.__get_ack__()
-            # self.__print__(hex(val))
-            return scale * (val) / 1.0e-1  # 100mS sampling
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.GET_ALTERNATE_HIGH_FREQUENCY)
+        self.H.__sendByte__(self.__calcDChan__(pin))
+        scale = self.H.__getByte__()
+        val = self.H.__getLong__()
+        self.H.__get_ack__()
+        # self.__print__(hex(val))
+        return scale * (val) / 1.0e-1  # 100mS sampling
 
     def get_freq(self, channel='CNTR', timeout=2):
         """
@@ -1484,22 +1378,20 @@ class ScienceLab():
 			(0.00025,6.25e-05)
 
 		"""
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.GET_FREQUENCY)
-            timeout_msb = int((timeout * 64e6)) >> 16
-            self.H.__sendInt__(timeout_msb)
-            self.H.__sendByte__(self.__calcDChan__(channel))
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.GET_FREQUENCY)
+        timeout_msb = int((timeout * 64e6)) >> 16
+        self.H.__sendInt__(timeout_msb)
+        self.H.__sendByte__(self.__calcDChan__(channel))
 
-            self.H.waitForData(timeout)
+        self.H.waitForData(timeout)
 
-            tmt = self.H.__getByte__()
-            x = [self.H.__getLong__() for a in range(2)]
-            self.H.__get_ack__()
-            freq = lambda t: 16 * 64e6 / t if (t) else 0
+        tmt = self.H.__getByte__()
+        x = [self.H.__getLong__() for a in range(2)]
+        self.H.__get_ack__()
+        freq = lambda t: 16 * 64e6 / t if (t) else 0
         # self.__print__(x,tmt,timeout_msb)
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+
         if (tmt): return 0
         return freq(x[1] - x[0])
 
@@ -1556,23 +1448,20 @@ class ScienceLab():
 		:return list: Array of points
 
 		"""
-        try:
-            if timeout > 60: timeout = 60
-            self.start_one_channel_LA(channel=channel, channel_mode=3, trigger_mode=0)  # every rising edge
-            startTime = time.time()
-            while time.time() - startTime < timeout:
-                a, b, c, d, e = self.get_LA_initial_states()
-                if a == self.MAX_SAMPLES / 4:
-                    a = 0
-                if a >= skip_cycle + 2:
-                    tmp = self.fetch_long_data_from_LA(a, 1)
-                    self.dchans[0].load_data(e, tmp)
-                    # print (self.dchans[0].timestamps)
-                    return [1e-6 * (self.dchans[0].timestamps[skip_cycle + 1] - self.dchans[0].timestamps[0])]
-                time.sleep(0.1)
-            return []
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        if timeout > 60: timeout = 60
+        self.start_one_channel_LA(channel=channel, channel_mode=3, trigger_mode=0)  # every rising edge
+        startTime = time.time()
+        while time.time() - startTime < timeout:
+            a, b, c, d, e = self.get_LA_initial_states()
+            if a == self.MAX_SAMPLES / 4:
+                a = 0
+            if a >= skip_cycle + 2:
+                tmp = self.fetch_long_data_from_LA(a, 1)
+                self.dchans[0].load_data(e, tmp)
+                # print (self.dchans[0].timestamps)
+                return [1e-6 * (self.dchans[0].timestamps[skip_cycle + 1] - self.dchans[0].timestamps[0])]
+            time.sleep(0.1)
+        return []
 
     def f2f_time(self, channel, skip_cycle=0, timeout=5):
         """
@@ -1591,23 +1480,20 @@ class ScienceLab():
 		:return list: Array of points
 
 		"""
-        try:
-            if timeout > 60: timeout = 60
-            self.start_one_channel_LA(channel=channel, channel_mode=2, trigger_mode=0)  # every falling edge
-            startTime = time.time()
-            while time.time() - startTime < timeout:
-                a, b, c, d, e = self.get_LA_initial_states()
-                if a == self.MAX_SAMPLES / 4:
-                    a = 0
-                if a >= skip_cycle + 2:
-                    tmp = self.fetch_long_data_from_LA(a, 1)
-                    self.dchans[0].load_data(e, tmp)
-                    # print (self.dchans[0].timestamps)
-                    return [1e-6 * (self.dchans[0].timestamps[skip_cycle + 1] - self.dchans[0].timestamps[0])]
-                time.sleep(0.1)
-            return []
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        if timeout > 60: timeout = 60
+        self.start_one_channel_LA(channel=channel, channel_mode=2, trigger_mode=0)  # every falling edge
+        startTime = time.time()
+        while time.time() - startTime < timeout:
+            a, b, c, d, e = self.get_LA_initial_states()
+            if a == self.MAX_SAMPLES / 4:
+                a = 0
+            if a >= skip_cycle + 2:
+                tmp = self.fetch_long_data_from_LA(a, 1)
+                self.dchans[0].load_data(e, tmp)
+                # print (self.dchans[0].timestamps)
+                return [1e-6 * (self.dchans[0].timestamps[skip_cycle + 1] - self.dchans[0].timestamps[0])]
+            time.sleep(0.1)
+        return []
 
     def MeasureInterval(self, channel1, channel2, edge1, edge2, timeout=0.1):
         """
@@ -1645,40 +1531,37 @@ class ScienceLab():
 
 
 		"""
-        try:
-            self.H.__sendByte__(CP.TIMING)
-            self.H.__sendByte__(CP.INTERVAL_MEASUREMENTS)
-            timeout_msb = int((timeout * 64e6)) >> 16
-            self.H.__sendInt__(timeout_msb)
+        self.H.__sendByte__(CP.TIMING)
+        self.H.__sendByte__(CP.INTERVAL_MEASUREMENTS)
+        timeout_msb = int((timeout * 64e6)) >> 16
+        self.H.__sendInt__(timeout_msb)
 
-            self.H.__sendByte__(self.__calcDChan__(channel1) | (self.__calcDChan__(channel2) << 4))
+        self.H.__sendByte__(self.__calcDChan__(channel1) | (self.__calcDChan__(channel2) << 4))
 
-            params = 0
-            if edge1 == 'rising':
-                params |= 3
-            elif edge1 == 'falling':
-                params |= 2
-            else:
-                params |= 4
+        params = 0
+        if edge1 == 'rising':
+            params |= 3
+        elif edge1 == 'falling':
+            params |= 2
+        else:
+            params |= 4
 
-            if edge2 == 'rising':
-                params |= 3 << 3
-            elif edge2 == 'falling':
-                params |= 2 << 3
-            else:
-                params |= 4 << 3
+        if edge2 == 'rising':
+            params |= 3 << 3
+        elif edge2 == 'falling':
+            params |= 2 << 3
+        else:
+            params |= 4 << 3
 
-            self.H.__sendByte__(params)
-            A = self.H.__getLong__()
-            B = self.H.__getLong__()
-            tmt = self.H.__getInt__()
-            self.H.__get_ack__()
-            # self.__print__(A,B)
-            if (tmt >= timeout_msb or B == 0): return np.NaN
-            rtime = lambda t: t / 64e6
-            return rtime(B - A + 20)
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(params)
+        A = self.H.__getLong__()
+        B = self.H.__getLong__()
+        tmt = self.H.__getInt__()
+        self.H.__get_ack__()
+        # self.__print__(A,B)
+        if (tmt >= timeout_msb or B == 0): return np.NaN
+        rtime = lambda t: t / 64e6
+        return rtime(B - A + 20)
 
     def DutyCycle(self, channel='ID1', timeout=1.):
         """
@@ -1703,24 +1586,21 @@ class ScienceLab():
 		.. seealso:: timing_example_
 
 		"""
-        try:
-            x, y = self.MeasureMultipleDigitalEdges(channel, channel, 'rising', 'falling', 2, 2, timeout, zero=True)
-            if x != None and y != None:  # Both timers registered something. did not timeout
-                if y[0] > 0:  # rising edge occured first
-                    dt = [y[0], x[1]]
-                else:  # falling edge occured first
-                    if y[1] > x[1]:
-                        return -1, -1  # Edge dropped. return False
-                    dt = [y[1], x[1]]
-                # self.__print__(x,y,dt)
-                params = dt[1], dt[0] / dt[1]
-                if params[1] > 0.5:
-                    self.__print__(x, y, dt)
-                return params
-            else:
-                return -1, -1
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        x, y = self.MeasureMultipleDigitalEdges(channel, channel, 'rising', 'falling', 2, 2, timeout, zero=True)
+        if x != None and y != None:  # Both timers registered something. did not timeout
+            if y[0] > 0:  # rising edge occured first
+                dt = [y[0], x[1]]
+            else:  # falling edge occured first
+                if y[1] > x[1]:
+                    return -1, -1  # Edge dropped. return False
+                dt = [y[1], x[1]]
+            # self.__print__(x,y,dt)
+            params = dt[1], dt[0] / dt[1]
+            if params[1] > 0.5:
+                self.__print__(x, y, dt)
+            return params
+        else:
+            return -1, -1
 
     def PulseTime(self, channel='ID1', PulseType='LOW', timeout=0.1):
         """
@@ -1746,22 +1626,19 @@ class ScienceLab():
 		.. seealso:: timing_example_
 
 		"""
-        try:
-            x, y = self.MeasureMultipleDigitalEdges(channel, channel, 'rising', 'falling', 2, 2, timeout, zero=True)
-            if x != None and y != None:  # Both timers registered something. did not timeout
-                if y[0] > 0:  # rising edge occured first
-                    if PulseType == 'HIGH':
-                        return y[0]
-                    elif PulseType == 'LOW':
-                        return x[1] - y[0]
-                else:  # falling edge occured first
-                    if PulseType == 'HIGH':
-                        return y[1]
-                    elif PulseType == 'LOW':
-                        return abs(y[0])
-            return -1, -1
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        x, y = self.MeasureMultipleDigitalEdges(channel, channel, 'rising', 'falling', 2, 2, timeout, zero=True)
+        if x != None and y != None:  # Both timers registered something. did not timeout
+            if y[0] > 0:  # rising edge occured first
+                if PulseType == 'HIGH':
+                    return y[0]
+                elif PulseType == 'LOW':
+                    return x[1] - y[0]
+            else:  # falling edge occured first
+                if PulseType == 'HIGH':
+                    return y[1]
+                elif PulseType == 'LOW':
+                    return abs(y[0])
+        return -1, -1
 
     def MeasureMultipleDigitalEdges(self, channel1, channel2, edgeType1, edgeType2, points1, points2, timeout=0.1,
                                     **kwargs):
@@ -1809,51 +1686,48 @@ class ScienceLab():
 
 
 		"""
-        try:
-            self.H.__sendByte__(CP.TIMING)
-            self.H.__sendByte__(CP.TIMING_MEASUREMENTS)
-            timeout_msb = int((timeout * 64e6)) >> 16
-            # print ('timeout',timeout_msb)
-            self.H.__sendInt__(timeout_msb)
-            self.H.__sendByte__(self.__calcDChan__(channel1) | (self.__calcDChan__(channel2) << 4))
-            params = 0
-            if edgeType1 == 'rising':
-                params |= 3
-            elif edgeType1 == 'falling':
-                params |= 2
-            else:
-                params |= 4
+        self.H.__sendByte__(CP.TIMING)
+        self.H.__sendByte__(CP.TIMING_MEASUREMENTS)
+        timeout_msb = int((timeout * 64e6)) >> 16
+        # print ('timeout',timeout_msb)
+        self.H.__sendInt__(timeout_msb)
+        self.H.__sendByte__(self.__calcDChan__(channel1) | (self.__calcDChan__(channel2) << 4))
+        params = 0
+        if edgeType1 == 'rising':
+            params |= 3
+        elif edgeType1 == 'falling':
+            params |= 2
+        else:
+            params |= 4
 
-            if edgeType2 == 'rising':
-                params |= 3 << 3
-            elif edgeType2 == 'falling':
-                params |= 2 << 3
-            else:
-                params |= 4 << 3
+        if edgeType2 == 'rising':
+            params |= 3 << 3
+        elif edgeType2 == 'falling':
+            params |= 2 << 3
+        else:
+            params |= 4 << 3
 
-            if ('SQR1' in kwargs):  # User wants to toggle SQ1 before starting the timer
-                params |= (1 << 6)
-                if kwargs['SQR1'] == 'HIGH': params |= (1 << 7)
-            self.H.__sendByte__(params)
-            if points1 > 4: points1 = 4
-            if points2 > 4: points2 = 4
-            self.H.__sendByte__(points1 | (points2 << 4))  # Number of points to fetch from either channel
+        if ('SQR1' in kwargs):  # User wants to toggle SQ1 before starting the timer
+            params |= (1 << 6)
+            if kwargs['SQR1'] == 'HIGH': params |= (1 << 7)
+        self.H.__sendByte__(params)
+        if points1 > 4: points1 = 4
+        if points2 > 4: points2 = 4
+        self.H.__sendByte__(points1 | (points2 << 4))  # Number of points to fetch from either channel
 
-            self.H.waitForData(timeout)
+        self.H.waitForData(timeout)
 
-            A = np.array([self.H.__getLong__() for a in range(points1)])
-            B = np.array([self.H.__getLong__() for a in range(points2)])
-            tmt = self.H.__getInt__()
-            self.H.__get_ack__()
-            # print(A,B)
-            if (tmt >= timeout_msb): return None, None
-            rtime = lambda t: t / 64e6
-            if (kwargs.get('zero', True)):  # User wants set a reference timestamp
-                return rtime(A - A[0]), rtime(B - A[0])
-            else:
-                return rtime(A), rtime(B)
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        A = np.array([self.H.__getLong__() for a in range(points1)])
+        B = np.array([self.H.__getLong__() for a in range(points2)])
+        tmt = self.H.__getInt__()
+        self.H.__get_ack__()
+        # print(A,B)
+        if (tmt >= timeout_msb): return None, None
+        rtime = lambda t: t / 64e6
+        if (kwargs.get('zero', True)):  # User wants set a reference timestamp
+            return rtime(A - A[0]), rtime(B - A[0])
+        else:
+            return rtime(A), rtime(B)
 
     def capture_edges1(self, waiting_time=1., **args):
         """
@@ -1899,17 +1773,14 @@ class ScienceLab():
         aqmode = args.get('channel_mode', 3)
         trmode = args.get('trigger_mode', 3)
 
-        try:
-            self.start_one_channel_LA(channel=aqchan, channel_mode=aqmode, trigger_channel=trchan, trigger_mode=trmode)
+        self.start_one_channel_LA(channel=aqchan, channel_mode=aqmode, trigger_channel=trchan, trigger_mode=trmode)
 
-            time.sleep(waiting_time)
+        time.sleep(waiting_time)
 
-            data = self.get_LA_initial_states()
-            tmp = self.fetch_long_data_from_LA(data[0], 1)
-            # data[4][0] -> initial state
-            return tmp / 64e6
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        data = self.get_LA_initial_states()
+        tmp = self.fetch_long_data_from_LA(data[0], 1)
+        # data[4][0] -> initial state
+        return tmp / 64e6
 
     def start_one_channel_LA_backup__(self, trigger=1, channel='ID1', maximum_time=67, **args):
         """
@@ -1933,43 +1804,39 @@ class ScienceLab():
 		:return: Nothing
 
 		"""
-        try:
-            self.clear_buffer(0, self.MAX_SAMPLES / 2)
-            self.H.__sendByte__(CP.TIMING)
-            self.H.__sendByte__(CP.START_ONE_CHAN_LA)
-            self.H.__sendInt__(self.MAX_SAMPLES / 4)
-            # trigchan bit functions
-            # b0 - trigger or not
-            # b1 - trigger edge . 1 => rising. 0 => falling
-            # b2, b3 - channel to acquire data from. ID1,ID2,ID3,ID4,COMPARATOR
-            # b4 - trigger channel ID1
-            # b5 - trigger channel ID2
-            # b6 - trigger channel ID3
+        self.clear_buffer(0, self.MAX_SAMPLES / 2)
+        self.H.__sendByte__(CP.TIMING)
+        self.H.__sendByte__(CP.START_ONE_CHAN_LA)
+        self.H.__sendInt__(self.MAX_SAMPLES / 4)
+        # trigchan bit functions
+        # b0 - trigger or not
+        # b1 - trigger edge . 1 => rising. 0 => falling
+        # b2, b3 - channel to acquire data from. ID1,ID2,ID3,ID4,COMPARATOR
+        # b4 - trigger channel ID1
+        # b5 - trigger channel ID2
+        # b6 - trigger channel ID3
 
-            if ('trigger_channels' in args) and trigger & 1:
-                trigchans = args.get('trigger_channels', 0)
-                if 'ID1' in trigchans: trigger |= (1 << 4)
-                if 'ID2' in trigchans: trigger |= (1 << 5)
-                if 'ID3' in trigchans: trigger |= (1 << 6)
-            else:
-                trigger |= 1 << (self.__calcDChan__(
-                    channel) + 4)  # trigger on specified input channel if not trigger_channel argument provided
+        if ('trigger_channels' in args) and trigger & 1:
+            trigchans = args.get('trigger_channels', 0)
+            if 'ID1' in trigchans: trigger |= (1 << 4)
+            if 'ID2' in trigchans: trigger |= (1 << 5)
+            if 'ID3' in trigchans: trigger |= (1 << 6)
+        else:
+            trigger |= 1 << (self.__calcDChan__(
+                channel) + 4)  # trigger on specified input channel if not trigger_channel argument provided
 
-            trigger |= 2 if args.get('edge', 0) == 'rising' else 0
-            trigger |= self.__calcDChan__(channel) << 2
+        trigger |= 2 if args.get('edge', 0) == 'rising' else 0
+        trigger |= self.__calcDChan__(channel) << 2
 
-            self.H.__sendByte__(trigger)
-            self.H.__get_ack__()
-            self.digital_channels_in_buffer = 1
-            for a in self.dchans:
-                a.prescaler = 0
-                a.datatype = 'long'
-                a.length = self.MAX_SAMPLES / 4
-                a.maximum_time = maximum_time * 1e6  # conversion to uS
-                a.mode = self.EVERY_EDGE
-
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(trigger)
+        self.H.__get_ack__()
+        self.digital_channels_in_buffer = 1
+        for a in self.dchans:
+            a.prescaler = 0
+            a.datatype = 'long'
+            a.length = self.MAX_SAMPLES / 4
+            a.maximum_time = maximum_time * 1e6  # conversion to uS
+            a.mode = self.EVERY_EDGE
 
             # def start_one_channel_LA(self,**args):
             """
@@ -2080,35 +1947,32 @@ class ScienceLab():
         # trigger_channel    ['ID1','ID2','ID3','ID4','SEN','EXT','CNTR']
         # trigger_mode       same as channel_mode.
         #				   default_value : 3
-        try:
-            self.clear_buffer(0, self.MAX_SAMPLES / 2)
-            self.H.__sendByte__(CP.TIMING)
-            self.H.__sendByte__(CP.START_ALTERNATE_ONE_CHAN_LA)
-            self.H.__sendInt__(self.MAX_SAMPLES / 4)
-            aqchan = self.__calcDChan__(args.get('channel', 'ID1'))
-            aqmode = args.get('channel_mode', 1)
-            trchan = self.__calcDChan__(args.get('trigger_channel', 'ID1'))
-            trmode = args.get('trigger_mode', 3)
+        self.clear_buffer(0, self.MAX_SAMPLES / 2)
+        self.H.__sendByte__(CP.TIMING)
+        self.H.__sendByte__(CP.START_ALTERNATE_ONE_CHAN_LA)
+        self.H.__sendInt__(self.MAX_SAMPLES / 4)
+        aqchan = self.__calcDChan__(args.get('channel', 'ID1'))
+        aqmode = args.get('channel_mode', 1)
+        trchan = self.__calcDChan__(args.get('trigger_channel', 'ID1'))
+        trmode = args.get('trigger_mode', 3)
 
-            self.H.__sendByte__((aqchan << 4) | aqmode)
-            self.H.__sendByte__((trchan << 4) | trmode)
-            self.H.__get_ack__()
-            self.digital_channels_in_buffer = 1
+        self.H.__sendByte__((aqchan << 4) | aqmode)
+        self.H.__sendByte__((trchan << 4) | trmode)
+        self.H.__get_ack__()
+        self.digital_channels_in_buffer = 1
 
-            a = self.dchans[0]
-            a.prescaler = 0
-            a.datatype = 'long'
-            a.length = self.MAX_SAMPLES / 4
-            a.maximum_time = 67 * 1e6  # conversion to uS
-            a.mode = args.get('channel_mode', 1)
-            a.name = args.get('channel', 'ID1')
+        a = self.dchans[0]
+        a.prescaler = 0
+        a.datatype = 'long'
+        a.length = self.MAX_SAMPLES / 4
+        a.maximum_time = 67 * 1e6  # conversion to uS
+        a.mode = args.get('channel_mode', 1)
+        a.name = args.get('channel', 'ID1')
 
-            if trmode in [3, 4, 5]:
-                a.initial_state_override = 2
-            elif trmode == 2:
-                a.initial_state_override = 1
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        if trmode in [3, 4, 5]:
+            a.initial_state_override = 2
+        elif trmode == 2:
+            a.initial_state_override = 1
 
     def start_two_channel_LA(self, **args):
         """
@@ -2161,29 +2025,26 @@ class ScienceLab():
         else:
             trigger = 0
 
-        try:
-            self.clear_buffer(0, self.MAX_SAMPLES)
-            self.H.__sendByte__(CP.TIMING)
-            self.H.__sendByte__(CP.START_TWO_CHAN_LA)
-            self.H.__sendInt__(self.MAX_SAMPLES / 4)
-            self.H.__sendByte__(trigger)
+        self.clear_buffer(0, self.MAX_SAMPLES)
+        self.H.__sendByte__(CP.TIMING)
+        self.H.__sendByte__(CP.START_TWO_CHAN_LA)
+        self.H.__sendInt__(self.MAX_SAMPLES / 4)
+        self.H.__sendByte__(trigger)
 
-            self.H.__sendByte__((modes[1] << 4) | modes[0])  # Modes. four bits each
-            self.H.__sendByte__((chans[1] << 4) | chans[0])  # Channels. four bits each
-            self.H.__get_ack__()
-            n = 0
-            for a in self.dchans[:2]:
-                a.prescaler = 0
-                a.length = self.MAX_SAMPLES / 4
-                a.datatype = 'long'
-                a.maximum_time = maximum_time * 1e6  # conversion to uS
-                a.mode = modes[n]
-                a.channel_number = chans[n]
-                a.name = strchans[n]
-                n += 1
-            self.digital_channels_in_buffer = 2
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__((modes[1] << 4) | modes[0])  # Modes. four bits each
+        self.H.__sendByte__((chans[1] << 4) | chans[0])  # Channels. four bits each
+        self.H.__get_ack__()
+        n = 0
+        for a in self.dchans[:2]:
+            a.prescaler = 0
+            a.length = self.MAX_SAMPLES / 4
+            a.datatype = 'long'
+            a.maximum_time = maximum_time * 1e6  # conversion to uS
+            a.mode = modes[n]
+            a.channel_number = chans[n]
+            a.name = strchans[n]
+            n += 1
+        self.digital_channels_in_buffer = 2
 
     def start_three_channel_LA(self, **args):
         """
@@ -2215,36 +2076,33 @@ class ScienceLab():
 		:return: Nothing
 
 		"""
-        try:
-            self.clear_buffer(0, self.MAX_SAMPLES)
-            self.H.__sendByte__(CP.TIMING)
-            self.H.__sendByte__(CP.START_THREE_CHAN_LA)
-            self.H.__sendInt__(self.MAX_SAMPLES / 4)
-            modes = args.get('modes', [1, 1, 1, 1])
-            trchan = self.__calcDChan__(args.get('trigger_channel', 'ID1'))
-            trmode = args.get('trigger_mode', 3)
+        self.clear_buffer(0, self.MAX_SAMPLES)
+        self.H.__sendByte__(CP.TIMING)
+        self.H.__sendByte__(CP.START_THREE_CHAN_LA)
+        self.H.__sendInt__(self.MAX_SAMPLES / 4)
+        modes = args.get('modes', [1, 1, 1, 1])
+        trchan = self.__calcDChan__(args.get('trigger_channel', 'ID1'))
+        trmode = args.get('trigger_mode', 3)
 
-            self.H.__sendInt__(modes[0] | (modes[1] << 4) | (modes[2] << 8))
-            self.H.__sendByte__((trchan << 4) | trmode)
+        self.H.__sendInt__(modes[0] | (modes[1] << 4) | (modes[2] << 8))
+        self.H.__sendByte__((trchan << 4) | trmode)
 
-            self.H.__get_ack__()
-            self.digital_channels_in_buffer = 3
+        self.H.__get_ack__()
+        self.digital_channels_in_buffer = 3
 
-            n = 0
-            for a in self.dchans[:3]:
-                a.prescaler = 0
-                a.length = self.MAX_SAMPLES / 4
-                a.datatype = 'int'
-                a.maximum_time = 1e3  # < 1 mS between each consecutive level changes in the input signal must be ensured to prevent rollover
-                a.mode = modes[n]
-                a.name = a.digital_channel_names[n]
-                if trmode in [3, 4, 5]:
-                    a.initial_state_override = 2
-                elif trmode == 2:
-                    a.initial_state_override = 1
-                n += 1
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        n = 0
+        for a in self.dchans[:3]:
+            a.prescaler = 0
+            a.length = self.MAX_SAMPLES / 4
+            a.datatype = 'int'
+            a.maximum_time = 1e3  # < 1 mS between each consecutive level changes in the input signal must be ensured to prevent rollover
+            a.mode = modes[n]
+            a.name = a.digital_channel_names[n]
+            if trmode in [3, 4, 5]:
+                a.initial_state_override = 2
+            elif trmode == 2:
+                a.initial_state_override = 1
+            n += 1
 
     def start_four_channel_LA(self, trigger=1, maximum_time=0.001, mode=[1, 1, 1, 1], **args):
         """
@@ -2297,33 +2155,30 @@ class ScienceLab():
 		elif(maximum_time > 0.0010239):
 			prescale = 1
 		"""
-        try:
-            self.H.__sendByte__(CP.TIMING)
-            self.H.__sendByte__(CP.START_FOUR_CHAN_LA)
-            self.H.__sendInt__(self.MAX_SAMPLES / 4)
-            self.H.__sendInt__(mode[0] | (mode[1] << 4) | (mode[2] << 8) | (mode[3] << 12))
-            self.H.__sendByte__(prescale)  # prescaler
-            trigopts = 0
-            trigopts |= 4 if args.get('trigger_ID1', 0) else 0
-            trigopts |= 8 if args.get('trigger_ID2', 0) else 0
-            trigopts |= 16 if args.get('trigger_ID3', 0) else 0
-            if (trigopts == 0): trigger |= 4  # select one trigger channel(ID1) if none selected
-            trigopts |= 2 if args.get('edge', 0) == 'rising' else 0
-            trigger |= trigopts
-            self.H.__sendByte__(trigger)
-            self.H.__get_ack__()
-            self.digital_channels_in_buffer = 4
-            n = 0
-            for a in self.dchans:
-                a.prescaler = prescale
-                a.length = self.MAX_SAMPLES / 4
-                a.datatype = 'int'
-                a.name = a.digital_channel_names[n]
-                a.maximum_time = maximum_time * 1e6  # conversion to uS
-                a.mode = mode[n]
-                n += 1
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.TIMING)
+        self.H.__sendByte__(CP.START_FOUR_CHAN_LA)
+        self.H.__sendInt__(self.MAX_SAMPLES / 4)
+        self.H.__sendInt__(mode[0] | (mode[1] << 4) | (mode[2] << 8) | (mode[3] << 12))
+        self.H.__sendByte__(prescale)  # prescaler
+        trigopts = 0
+        trigopts |= 4 if args.get('trigger_ID1', 0) else 0
+        trigopts |= 8 if args.get('trigger_ID2', 0) else 0
+        trigopts |= 16 if args.get('trigger_ID3', 0) else 0
+        if (trigopts == 0): trigger |= 4  # select one trigger channel(ID1) if none selected
+        trigopts |= 2 if args.get('edge', 0) == 'rising' else 0
+        trigger |= trigopts
+        self.H.__sendByte__(trigger)
+        self.H.__get_ack__()
+        self.digital_channels_in_buffer = 4
+        n = 0
+        for a in self.dchans:
+            a.prescaler = prescale
+            a.length = self.MAX_SAMPLES / 4
+            a.datatype = 'int'
+            a.name = a.digital_channel_names[n]
+            a.maximum_time = maximum_time * 1e6  # conversion to uS
+            a.mode = mode[n]
+            n += 1
 
     def get_LA_initial_states(self):
         """
@@ -2331,29 +2186,26 @@ class ScienceLab():
 
 		:return: chan1 progress,chan2 progress,chan3 progress,chan4 progress,[ID1,ID2,ID3,ID4]. eg. [1,0,1,1]
 		"""
-        try:
-            self.H.__sendByte__(CP.TIMING)
-            self.H.__sendByte__(CP.GET_INITIAL_DIGITAL_STATES)
-            initial = self.H.__getInt__()
-            A = (self.H.__getInt__() - initial) / 2
-            B = (self.H.__getInt__() - initial) / 2 - self.MAX_SAMPLES / 4
-            C = (self.H.__getInt__() - initial) / 2 - 2 * self.MAX_SAMPLES / 4
-            D = (self.H.__getInt__() - initial) / 2 - 3 * self.MAX_SAMPLES / 4
-            s = self.H.__getByte__()
-            s_err = self.H.__getByte__()
-            self.H.__get_ack__()
+        self.H.__sendByte__(CP.TIMING)
+        self.H.__sendByte__(CP.GET_INITIAL_DIGITAL_STATES)
+        initial = self.H.__getInt__()
+        A = (self.H.__getInt__() - initial) / 2
+        B = (self.H.__getInt__() - initial) / 2 - self.MAX_SAMPLES / 4
+        C = (self.H.__getInt__() - initial) / 2 - 2 * self.MAX_SAMPLES / 4
+        D = (self.H.__getInt__() - initial) / 2 - 3 * self.MAX_SAMPLES / 4
+        s = self.H.__getByte__()
+        s_err = self.H.__getByte__()
+        self.H.__get_ack__()
 
-            if A == 0: A = self.MAX_SAMPLES / 4
-            if B == 0: B = self.MAX_SAMPLES / 4
-            if C == 0: C = self.MAX_SAMPLES / 4
-            if D == 0: D = self.MAX_SAMPLES / 4
+        if A == 0: A = self.MAX_SAMPLES / 4
+        if B == 0: B = self.MAX_SAMPLES / 4
+        if C == 0: C = self.MAX_SAMPLES / 4
+        if D == 0: D = self.MAX_SAMPLES / 4
 
-            if A < 0: A = 0
-            if B < 0: B = 0
-            if C < 0: C = 0
-            if D < 0: D = 0
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        if A < 0: A = 0
+        if B < 0: B = 0
+        if C < 0: C = 0
+        if D < 0: D = 0
 
         return A, B, C, D, {'ID1': (s & 1 != 0), 'ID2': (s & 2 != 0), 'ID3': (s & 4 != 0), 'ID4': (s & 8 != 0),
                             'SEN': (s & 16 != 16)}  # SEN is inverted comparator output.
@@ -2362,12 +2214,9 @@ class ScienceLab():
         """
 		Stop any running logic analyzer function
 		"""
-        try:
-            self.H.__sendByte__(CP.TIMING)
-            self.H.__sendByte__(CP.STOP_LA)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.TIMING)
+        self.H.__sendByte__(CP.STOP_LA)
+        self.H.__get_ack__()
 
     def fetch_int_data_from_LA(self, bytes, chan=1):
         """
@@ -2382,20 +2231,17 @@ class ScienceLab():
 		chan:           channel number (1-4)
 		==============  ============================================================================================
 		"""
-        try:
-            self.H.__sendByte__(CP.TIMING)
-            self.H.__sendByte__(CP.FETCH_INT_DMA_DATA)
-            self.H.__sendInt__(bytes)
-            self.H.__sendByte__(chan - 1)
+        self.H.__sendByte__(CP.TIMING)
+        self.H.__sendByte__(CP.FETCH_INT_DMA_DATA)
+        self.H.__sendInt__(bytes)
+        self.H.__sendByte__(chan - 1)
 
-            ss = self.H.fd.read(int(bytes * 2))
-            t = np.zeros(int(bytes) * 2)
-            for a in range(int(bytes)):
-                t[a] = CP.ShortInt.unpack(ss[a * 2:a * 2 + 2])[0]
+        ss = self.H.fd.read(int(bytes * 2))
+        t = np.zeros(int(bytes) * 2)
+        for a in range(int(bytes)):
+            t[a] = CP.ShortInt.unpack(ss[a * 2:a * 2 + 2])[0]
 
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__get_ack__()
 
         t = np.trim_zeros(t)
         b = 1
@@ -2420,57 +2266,48 @@ class ScienceLab():
 		chan:           channel number (1,2)
 		==============  ============================================================================================
 		"""
-        try:
-            self.H.__sendByte__(CP.TIMING)
-            self.H.__sendByte__(CP.FETCH_LONG_DMA_DATA)
-            self.H.__sendInt__(bytes)
-            self.H.__sendByte__(chan - 1)
-            ss = self.H.fd.read(int(bytes * 4))
-            self.H.__get_ack__()
-            tmp = np.zeros(int(bytes))
-            for a in range(int(bytes)):
-                tmp[a] = CP.Integer.unpack(ss[a * 4:a * 4 + 4])[0]
-            tmp = np.trim_zeros(tmp)
-            return tmp
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.TIMING)
+        self.H.__sendByte__(CP.FETCH_LONG_DMA_DATA)
+        self.H.__sendInt__(bytes)
+        self.H.__sendByte__(chan - 1)
+        ss = self.H.fd.read(int(bytes * 4))
+        self.H.__get_ack__()
+        tmp = np.zeros(int(bytes))
+        for a in range(int(bytes)):
+            tmp[a] = CP.Integer.unpack(ss[a * 4:a * 4 + 4])[0]
+        tmp = np.trim_zeros(tmp)
+        return tmp
 
     def fetch_LA_channels(self):
         """
 		reads and stores the channels in self.dchans.
 
 		"""
-        try:
-            data = self.get_LA_initial_states()
-            # print (data)
-            for a in range(4):
-                if (self.dchans[a].channel_number < self.digital_channels_in_buffer): self.__fetch_LA_channel__(a, data)
-            return True
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        data = self.get_LA_initial_states()
+        # print (data)
+        for a in range(4):
+            if (self.dchans[a].channel_number < self.digital_channels_in_buffer): self.__fetch_LA_channel__(a, data)
+        return True
 
     def __fetch_LA_channel__(self, channel_number, initial_states):
-        try:
-            s = initial_states[4]
-            a = self.dchans[channel_number]
-            if a.channel_number >= self.digital_channels_in_buffer:
-                self.__print__('channel unavailable')
-                return False
+        s = initial_states[4]
+        a = self.dchans[channel_number]
+        if a.channel_number >= self.digital_channels_in_buffer:
+            self.__print__('channel unavailable')
+            return False
 
-            samples = a.length
-            if a.datatype == 'int':
-                tmp = self.fetch_int_data_from_LA(initial_states[a.channel_number], a.channel_number + 1)
-                a.load_data(s, tmp)
-            else:
-                tmp = self.fetch_long_data_from_LA(initial_states[a.channel_number * 2], a.channel_number + 1)
-                a.load_data(s, tmp)
+        samples = a.length
+        if a.datatype == 'int':
+            tmp = self.fetch_int_data_from_LA(initial_states[a.channel_number], a.channel_number + 1)
+            a.load_data(s, tmp)
+        else:
+            tmp = self.fetch_long_data_from_LA(initial_states[a.channel_number * 2], a.channel_number + 1)
+            a.load_data(s, tmp)
 
-            # offset=0
-            # a.timestamps -= offset
-            a.generate_axes()
-            return True
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        # offset=0
+        # a.timestamps -= offset
+        a.generate_axes()
+        return True
 
     def get_states(self):
         """
@@ -2480,14 +2317,11 @@ class ScienceLab():
 		{'ID1': True, 'ID2': True, 'ID3': True, 'ID4': False}
 
 		"""
-        try:
-            self.H.__sendByte__(CP.DIN)
-            self.H.__sendByte__(CP.GET_STATES)
-            s = self.H.__getByte__()
-            self.H.__get_ack__()
-            return {'ID1': (s & 1 != 0), 'ID2': (s & 2 != 0), 'ID3': (s & 4 != 0), 'ID4': (s & 8 != 0)}
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.DIN)
+        self.H.__sendByte__(CP.GET_STATES)
+        s = self.H.__getByte__()
+        self.H.__get_ack__()
+        return {'ID1': (s & 1 != 0), 'ID2': (s & 2 != 0), 'ID3': (s & 4 != 0), 'ID4': (s & 8 != 0)}
 
     def get_state(self, input_id):
         """
@@ -2536,13 +2370,10 @@ class ScienceLab():
             data |= 0x40 | (kwargs.get('SQR3') << 2)
         if 'SQR4' in kwargs:
             data |= 0x80 | (kwargs.get('SQR4') << 3)
-        try:
-            self.H.__sendByte__(CP.DOUT)
-            self.H.__sendByte__(CP.SET_STATE)
-            self.H.__sendByte__(data)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.DOUT)
+        self.H.__sendByte__(CP.SET_STATE)
+        self.H.__sendByte__(data)
+        self.H.__get_ack__()
 
     def countPulses(self, channel='SEN'):
         """
@@ -2557,13 +2388,10 @@ class ScienceLab():
 		channel         The input pin to measure rising edges on : ['ID1','ID2','ID3','ID4','SEN','EXT','CNTR']
 		==============  ============================================================================================
 		"""
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.START_COUNTING)
-            self.H.__sendByte__(self.__calcDChan__(channel))
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.START_COUNTING)
+        self.H.__sendByte__(self.__calcDChan__(channel))
+        self.H.__get_ack__()
 
     def readPulseCount(self):
         """
@@ -2577,75 +2405,56 @@ class ScienceLab():
 		==============  ============================================================================================
 		==============  ============================================================================================
 		"""
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.FETCH_COUNT)
-            count = self.H.__getInt__()
-            self.H.__get_ack__()
-            return count
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.FETCH_COUNT)
+        count = self.H.__getInt__()
+        self.H.__get_ack__()
+        return count
 
     def __charge_cap__(self, state, t):
-        try:
-            self.H.__sendByte__(CP.ADC)
-            self.H.__sendByte__(CP.SET_CAP)
-            self.H.__sendByte__(state)
-            self.H.__sendInt__(t)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.ADC)
+        self.H.__sendByte__(CP.SET_CAP)
+        self.H.__sendByte__(state)
+        self.H.__sendInt__(t)
+        self.H.__get_ack__()
 
     def __capture_capacitance__(self, samples, tg):
         from PSL.analyticsClass import analyticsClass
         self.AC = analyticsClass()
         self.__charge_cap__(1, 50000)
-        try:
-            x, y = self.capture_fullspeed_hr('CAP', samples, tg, 'READ_CAP')
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
-        try:
-            fitres = self.AC.fit_exp(x * 1e-6, y)
-            if fitres:
-                cVal, newy = fitres
-                # from PSL import *
-                # plot(x,newy)
-                # show()
-                return x, y, newy, cVal
-            else:
-                return None
-        except Exception as ex:
-            raise RuntimeError(" Fit Failed ")
+        x, y = self.capture_fullspeed_hr('CAP', samples, tg, 'READ_CAP')
+        fitres = self.AC.fit_exp(x * 1e-6, y)
+        if fitres:
+            cVal, newy = fitres
+            # from PSL import *
+            # plot(x,newy)
+            # show()
+            return x, y, newy, cVal
+        else:
+            return None
 
     def capacitance_via_RC_discharge(self):
         cap = self.get_capacitor_range()[1]
         T = 2 * cap * 20e3 * 1e6  # uS
         samples = 500
-        try:
-            if T > 5000 and T < 10e6:
-                if T > 50e3: samples = 250
-                RC = self.__capture_capacitance__(samples, int(T / samples))[3][1]
-                return RC / 10e3
-            else:
-                self.__print__('cap out of range %f %f' % (T, cap))
-                return 0
-        except Exception as e:
-            self.__print__(e)
+        if T > 5000 and T < 10e6:
+            if T > 50e3: samples = 250
+            RC = self.__capture_capacitance__(samples, int(T / samples))[3][1]
+            return RC / 10e3
+        else:
+            self.__print__('cap out of range %f %f' % (T, cap))
             return 0
 
     def __get_capacitor_range__(self, ctime):
-        try:
-            self.__charge_cap__(0, 30000)
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.GET_CAP_RANGE)
-            self.H.__sendInt__(ctime)
-            V_sum = self.H.__getInt__()
-            self.H.__get_ack__()
-            V = V_sum * 3.3 / 16 / 4095
-            C = -ctime * 1e-6 / 1e4 / np.log(1 - V / 3.3)
-            return V, C
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.__charge_cap__(0, 30000)
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.GET_CAP_RANGE)
+        self.H.__sendInt__(ctime)
+        V_sum = self.H.__getInt__()
+        self.H.__get_ack__()
+        V = V_sum * 3.3 / 16 / 4095
+        C = -ctime * 1e-6 / 1e4 / np.log(1 - V / 3.3)
+        return V, C
 
     def get_capacitor_range(self):
         """
@@ -2689,36 +2498,34 @@ class ScienceLab():
         CR = 1
         iterations = 0
         start_time = time.time()
-        try:
-            while (time.time() - start_time) < 1:
-                # self.__print__('vals',CR,',',CT)
-                if CT > 65000:
-                    self.__print__('CT too high')
-                    return self.capacitance_via_RC_discharge()
-                V, C = self.__get_capacitance__(CR, 0, CT)
-                # print(CR,CT,V,C)
-                if CT > 30000 and V < 0.1:
-                    self.__print__('Capacitance too high for this method')
-                    return 0
 
-                elif V > GOOD_VOLTS[0] and V < GOOD_VOLTS[1]:
+        while (time.time() - start_time) < 1:
+            # self.__print__('vals',CR,',',CT)
+            if CT > 65000:
+                self.__print__('CT too high')
+                return self.capacitance_via_RC_discharge()
+            V, C = self.__get_capacitance__(CR, 0, CT)
+            # print(CR,CT,V,C)
+            if CT > 30000 and V < 0.1:
+                self.__print__('Capacitance too high for this method')
+                return 0
+
+            elif V > GOOD_VOLTS[0] and V < GOOD_VOLTS[1]:
+                return C
+            elif V < GOOD_VOLTS[0] and V > 0.01 and CT < 40000:
+                if GOOD_VOLTS[0] / V > 1.1 and iterations < 10:
+                    CT = int(CT * GOOD_VOLTS[0] / V)
+                    iterations += 1
+                    self.__print__('increased CT ', CT)
+                elif iterations == 10:
+                    return 0
+                else:
                     return C
-                elif V < GOOD_VOLTS[0] and V > 0.01 and CT < 40000:
-                    if GOOD_VOLTS[0] / V > 1.1 and iterations < 10:
-                        CT = int(CT * GOOD_VOLTS[0] / V)
-                        iterations += 1
-                        self.__print__('increased CT ', CT)
-                    elif iterations == 10:
-                        return 0
-                    else:
-                        return C
-                elif V <= 0.1 and CR < 3:
-                    CR += 1
-                elif CR == 3:
-                    self.__print__('Capture mode ')
-                    return self.capacitance_via_RC_discharge()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+            elif V <= 0.1 and CR < 3:
+                CR += 1
+            elif CR == 3:
+                self.__print__('Capture mode ')
+                return self.capacitance_via_RC_discharge()
 
     def __calibrate_ctmu__(self, scalers):
         # self.currents=[0.55e-3/scalers[0],0.55e-6/scalers[1],0.55e-5/scalers[2],0.55e-4/scalers[3]]
@@ -2728,30 +2535,27 @@ class ScienceLab():
     # print (self.currentScalers,scalers,self.SOCKET_CAPACITANCE)
 
     def __get_capacitance__(self, current_range, trim, Charge_Time):  # time in uS
-        try:
-            self.__charge_cap__(0, 30000)
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.GET_CAPACITANCE)
-            self.H.__sendByte__(current_range)
-            if (trim < 0):
-                self.H.__sendByte__(int(31 - abs(trim) / 2) | 32)
-            else:
-                self.H.__sendByte__(int(trim / 2))
-            self.H.__sendInt__(Charge_Time)
-            time.sleep(Charge_Time * 1e-6 + .02)
-            VCode = self.H.__getInt__()
-            V = 3.3 * VCode / 4095
-            self.H.__get_ack__()
-            Charge_Current = self.currents[current_range] * (100 + trim) / 100.0
-            if V:
-                C = (Charge_Current * Charge_Time * 1e-6 / V - self.SOCKET_CAPACITANCE) / self.currentScalers[
-                    current_range]
-            else:
-                C = 0
-            # self.__print__('Current if C=470pF :',V*(470e-12+self.SOCKET_CAPACITANCE)/(Charge_Time*1e-6))
-            return V, C
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.__charge_cap__(0, 30000)
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.GET_CAPACITANCE)
+        self.H.__sendByte__(current_range)
+        if (trim < 0):
+            self.H.__sendByte__(int(31 - abs(trim) / 2) | 32)
+        else:
+            self.H.__sendByte__(int(trim / 2))
+        self.H.__sendInt__(Charge_Time)
+        time.sleep(Charge_Time * 1e-6 + .02)
+        VCode = self.H.__getInt__()
+        V = 3.3 * VCode / 4095
+        self.H.__get_ack__()
+        Charge_Current = self.currents[current_range] * (100 + trim) / 100.0
+        if V:
+            C = (Charge_Current * Charge_Time * 1e-6 / V - self.SOCKET_CAPACITANCE) / self.currentScalers[
+                current_range]
+        else:
+            C = 0
+        # self.__print__('Current if C=470pF :',V*(470e-12+self.SOCKET_CAPACITANCE)/(Charge_Time*1e-6))
+        return V, C
 
     def get_temperature(self):
         """
@@ -2786,51 +2590,40 @@ class ScienceLab():
 		:return: Voltage
 		"""
         if channel == 'CAP': channel = 5
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.GET_CTMU_VOLTAGE)
-            self.H.__sendByte__((channel) | (Crange << 5) | (tgen << 7))
 
-            # V = [self.H.__getInt__() for a in range(16)]
-            # print(V)
-            # V=V[3:]
-            v = self.H.__getInt__()  # 16*voltage across the current source
-            # v=sum(V)
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.GET_CTMU_VOLTAGE)
+        self.H.__sendByte__((channel) | (Crange << 5) | (tgen << 7))
 
-            self.H.__get_ack__()
-            V = 3.3 * v / 16 / 4095.
-            # print(V)
-            return V
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        # V = [self.H.__getInt__() for a in range(16)]
+        # print(V)
+        # V=V[3:]
+        v = self.H.__getInt__()  # 16*voltage across the current source
+        # v=sum(V)
+
+        self.H.__get_ack__()
+        V = 3.3 * v / 16 / 4095.
+        # print(V)
+        return V
 
     def __start_ctmu__(self, Crange, trim, tgen=1):
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.START_CTMU)
-            self.H.__sendByte__((Crange) | (tgen << 7))
-            self.H.__sendByte__(trim)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.START_CTMU)
+        self.H.__sendByte__((Crange) | (tgen << 7))
+        self.H.__sendByte__(trim)
+        self.H.__get_ack__()
 
     def __stop_ctmu__(self):
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.STOP_CTMU)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.STOP_CTMU)
+        self.H.__get_ack__()
 
     def resetHardware(self):
         """
 		Resets the device, and standalone mode will be enabled if an OLED is connected to the I2C port
 		"""
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.RESTORE_STANDALONE)
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.RESTORE_STANDALONE)
 
     def read_flash(self, page, location):
         """
@@ -2847,16 +2640,13 @@ class ScienceLab():
 
 		:return: a string of 16 characters read from the location
 		"""
-        try:
-            self.H.__sendByte__(CP.FLASH)
-            self.H.__sendByte__(CP.READ_FLASH)
-            self.H.__sendByte__(page)  # send the page number. 20 pages with 2K bytes each
-            self.H.__sendByte__(location)  # send the location
-            ss = self.H.fd.read(16)
-            self.H.__get_ack__()
-            return ss
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.FLASH)
+        self.H.__sendByte__(CP.READ_FLASH)
+        self.H.__sendByte__(page)  # send the page number. 20 pages with 2K bytes each
+        self.H.__sendByte__(location)  # send the location
+        ss = self.H.fd.read(16)
+        self.H.__get_ack__()
+        return ss
 
     def __stoa__(self, s):
         return [ord(a) for a in s.decode('utf-8')]
@@ -2879,20 +2669,17 @@ class ScienceLab():
 
 		:return: a string of 16 characters read from the location
 		"""
-        try:
-            self.H.__sendByte__(CP.FLASH)
-            self.H.__sendByte__(CP.READ_BULK_FLASH)
-            bytes_to_read = numbytes
-            if numbytes % 2: bytes_to_read += 1  # bytes+1 . stuff is stored as integers (byte+byte) in the hardware
-            self.H.__sendInt__(bytes_to_read)
-            self.H.__sendByte__(page)
-            ss = self.H.fd.read(int(bytes_to_read))
-            self.H.__get_ack__()
-            self.__print__('Read from ', page, ',', bytes_to_read, ' :', self.__stoa__(ss[:40]), '...')
-            if numbytes % 2: return ss[:-1]  # Kill the extra character we read. Don't surprise the user with extra data
-            return ss
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.FLASH)
+        self.H.__sendByte__(CP.READ_BULK_FLASH)
+        bytes_to_read = numbytes
+        if numbytes % 2: bytes_to_read += 1  # bytes+1 . stuff is stored as integers (byte+byte) in the hardware
+        self.H.__sendInt__(bytes_to_read)
+        self.H.__sendByte__(page)
+        ss = self.H.fd.read(int(bytes_to_read))
+        self.H.__get_ack__()
+        self.__print__('Read from ', page, ',', bytes_to_read, ' :', self.__stoa__(ss[:40]), '...')
+        if numbytes % 2: return ss[:-1]  # Kill the extra character we read. Don't surprise the user with extra data
+        return ss
 
     def write_flash(self, page, location, string_to_write):
         """
@@ -2914,17 +2701,14 @@ class ScienceLab():
 		================    ============================================================================================
 
 		"""
-        try:
-            while (len(string_to_write) < 16): string_to_write += '.'
-            self.H.__sendByte__(CP.FLASH)
-            self.H.__sendByte__(CP.WRITE_FLASH)  # indicate a flash write coming through
-            self.H.__sendByte__(page)  # send the page number. 20 pages with 2K bytes each
-            self.H.__sendByte__(location)  # send the location
-            self.H.fd.write(string_to_write)
-            time.sleep(0.1)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        while (len(string_to_write) < 16): string_to_write += '.'
+        self.H.__sendByte__(CP.FLASH)
+        self.H.__sendByte__(CP.WRITE_FLASH)  # indicate a flash write coming through
+        self.H.__sendByte__(page)  # send the page number. 20 pages with 2K bytes each
+        self.H.__sendByte__(location)  # send the location
+        self.H.fd.write(string_to_write)
+        time.sleep(0.1)
+        self.H.__get_ack__()
 
     def write_bulk_flash(self, location, data):
         """
@@ -2947,23 +2731,21 @@ class ScienceLab():
 		"""
         if (type(data) == str): data = [ord(a) for a in data]
         if len(data) % 2 == 1: data.append(0)
-        try:
-            # self.__print__('Dumping at',location,',',len(bytearray),' bytes into flash',bytearray[:10])
-            self.H.__sendByte__(CP.FLASH)
-            self.H.__sendByte__(CP.WRITE_BULK_FLASH)  # indicate a flash write coming through
-            self.H.__sendInt__(len(data))  # send the length
-            self.H.__sendByte__(location)
-            for n in range(len(data)):
-                self.H.__sendByte__(data[n])
-            # Printer('Bytes written: %d'%(n+1))
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
 
-            # verification by readback
-            tmp = [ord(a) for a in self.read_bulk_flash(location, len(data))]
-            print('Verification done', tmp == data)
-            if tmp != data: raise Exception('Verification by readback failed')
+        # self.__print__('Dumping at',location,',',len(bytearray),' bytes into flash',bytearray[:10])
+        self.H.__sendByte__(CP.FLASH)
+        self.H.__sendByte__(CP.WRITE_BULK_FLASH)  # indicate a flash write coming through
+        self.H.__sendInt__(len(data))  # send the length
+        self.H.__sendByte__(location)
+        for n in range(len(data)):
+            self.H.__sendByte__(data[n])
+        # Printer('Bytes written: %d'%(n+1))
+        self.H.__get_ack__()
+
+        # verification by readback
+        tmp = [ord(a) for a in self.read_bulk_flash(location, len(data))]
+        print('Verification done', tmp == data)
+        if tmp != data: raise Exception('Verification by readback failed')
 
     # -------------------------------------------------------------------------------------------------------------------#
 
@@ -3070,17 +2852,14 @@ class ScienceLab():
             self.__print__('out of range')
             return 0
 
-        try:
-            self.H.__sendByte__(CP.WAVEGEN)
-            self.H.__sendByte__(CP.SET_SINE1)
-            self.H.__sendByte__(HIGHRES | (prescaler << 1))  # use larger table for low frequencies
-            self.H.__sendInt__(wavelength - 1)
-            self.H.__get_ack__()
-            # if self.sine1freq == None: time.sleep(0.2)
-            self.sine1freq = freq
-            return freq
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.WAVEGEN)
+        self.H.__sendByte__(CP.SET_SINE1)
+        self.H.__sendByte__(HIGHRES | (prescaler << 1))  # use larger table for low frequencies
+        self.H.__sendInt__(wavelength - 1)
+        self.H.__get_ack__()
+        # if self.sine1freq == None: time.sleep(0.2)
+        self.sine1freq = freq
+        return freq
 
     def set_w2(self, freq, waveType=None):
         """
@@ -3123,16 +2902,14 @@ class ScienceLab():
         if prescaler == 4:
             self.__print__('out of range')
             return 0
-        try:
-            self.H.__sendByte__(CP.WAVEGEN)
-            self.H.__sendByte__(CP.SET_SINE2)
-            self.H.__sendByte__(HIGHRES | (prescaler << 1))  # use larger table for low frequencies
-            self.H.__sendInt__(wavelength - 1)
-            self.H.__get_ack__()
-            # if self.sine2freq == None: time.sleep(0.2)
-            self.sine2freq = freq
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+
+        self.H.__sendByte__(CP.WAVEGEN)
+        self.H.__sendByte__(CP.SET_SINE2)
+        self.H.__sendByte__(HIGHRES | (prescaler << 1))  # use larger table for low frequencies
+        self.H.__sendInt__(wavelength - 1)
+        self.H.__get_ack__()
+        # if self.sine2freq == None: time.sleep(0.2)
+        self.sine2freq = freq
 
         return freq
 
@@ -3226,26 +3003,23 @@ class ScienceLab():
         phase_coarse = int(table_size2 * (phase) / 360.)
         phase_fine = int(wavelength2 * (phase - (phase_coarse) * 360. / table_size2) / (360. / table_size2))
 
-        try:
-            self.H.__sendByte__(CP.WAVEGEN)
-            self.H.__sendByte__(CP.SET_BOTH_WG)
+        self.H.__sendByte__(CP.WAVEGEN)
+        self.H.__sendByte__(CP.SET_BOTH_WG)
 
-            self.H.__sendInt__(wavelength - 1)  # not really wavelength. time between each datapoint
-            self.H.__sendInt__(wavelength2 - 1)  # not really wavelength. time between each datapoint
-            self.H.__sendInt__(phase_coarse)  # table position for phase adjust
-            self.H.__sendInt__(phase_fine)  # timer delay / fine phase adjust
+        self.H.__sendInt__(wavelength - 1)  # not really wavelength. time between each datapoint
+        self.H.__sendInt__(wavelength2 - 1)  # not really wavelength. time between each datapoint
+        self.H.__sendInt__(phase_coarse)  # table position for phase adjust
+        self.H.__sendInt__(phase_fine)  # timer delay / fine phase adjust
 
-            self.H.__sendByte__((prescaler2 << 4) | (prescaler1 << 2) | (HIGHRES2 << 1) | (
-                HIGHRES))  # use larger table for low frequencies
-            self.H.__get_ack__()
-            # print ( phase_coarse,phase_fine)
-            # if self.sine1freq == None or self.sine2freq==None : time.sleep(0.2)
-            self.sine1freq = retfreq
-            self.sine2freq = retfreq2
+        self.H.__sendByte__((prescaler2 << 4) | (prescaler1 << 2) | (HIGHRES2 << 1) | (
+            HIGHRES))  # use larger table for low frequencies
+        self.H.__get_ack__()
+        # print ( phase_coarse,phase_fine)
+        # if self.sine1freq == None or self.sine2freq==None : time.sleep(0.2)
+        self.sine1freq = retfreq
+        self.sine2freq = retfreq2
 
-            return retfreq
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        return retfreq
 
     def load_equation(self, chan, function, span=None, **kwargs):
         '''
@@ -3334,24 +3108,21 @@ class ScienceLab():
         y2 = 1. - y2
         y2 = list(np.int16(np.round(SMALL_MAX - SMALL_MAX * y2)))
 
-        try:
-            self.H.__sendByte__(CP.WAVEGEN)
-            if (num == 1):
-                self.H.__sendByte__(CP.LOAD_WAVEFORM1)
-            elif (num == 2):
-                self.H.__sendByte__(CP.LOAD_WAVEFORM2)
+        self.H.__sendByte__(CP.WAVEGEN)
+        if (num == 1):
+            self.H.__sendByte__(CP.LOAD_WAVEFORM1)
+        elif (num == 2):
+            self.H.__sendByte__(CP.LOAD_WAVEFORM2)
 
-            # print(max(y1),max(y2))
-            for a in y1:
-                self.H.__sendInt__(a)
-            # time.sleep(0.001)
-            for a in y2:
-                self.H.__sendByte__(CP.Byte.pack(a))
-            # time.sleep(0.001)
-            time.sleep(0.01)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        # print(max(y1),max(y2))
+        for a in y1:
+            self.H.__sendInt__(a)
+        # time.sleep(0.001)
+        for a in y2:
+            self.H.__sendByte__(CP.Byte.pack(a))
+        # time.sleep(0.001)
+        time.sleep(0.01)
+        self.H.__get_ack__()
 
     def sqr1(self, freq, duty_cycle=50, onlyPrepare=False):
         """
@@ -3383,16 +3154,14 @@ class ScienceLab():
         high_time = wavelength * duty_cycle / 100.
         self.__print__(wavelength, ':', high_time, ':', prescaler)
         if onlyPrepare: self.set_state(SQR1=False)
-        try:
-            self.H.__sendByte__(CP.WAVEGEN)
-            self.H.__sendByte__(CP.SET_SQR1)
-            self.H.__sendInt__(int(round(wavelength)))
-            self.H.__sendInt__(int(round(high_time)))
-            if onlyPrepare: prescaler |= 0x4  # Instruct hardware to prepare the square wave, but do not connect it to the output.
-            self.H.__sendByte__(prescaler)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+
+        self.H.__sendByte__(CP.WAVEGEN)
+        self.H.__sendByte__(CP.SET_SQR1)
+        self.H.__sendInt__(int(round(wavelength)))
+        self.H.__sendInt__(int(round(high_time)))
+        if onlyPrepare: prescaler |= 0x4  # Instruct hardware to prepare the square wave, but do not connect it to the output.
+        self.H.__sendByte__(prescaler)
+        self.H.__get_ack__()
 
         self.sqrfreq['SQR1'] = 64e6 / wavelength / p[prescaler & 0x3]
         return self.sqrfreq['SQR1']
@@ -3416,14 +3185,13 @@ class ScienceLab():
 			I.sqr1_pattern([1000,1000,1000,1000,1000])  #On:1mS (38KHz packet), Off:1mS, On:1mS (38KHz packet), Off:1mS, On:1mS (38KHz packet), Off: indefinitely..
 		"""
         self.fill_buffer(self.MAX_SAMPLES / 2, timing_array)  # Load the array to the ADCBuffer(second half)
-        try:
-            self.H.__sendByte__(CP.WAVEGEN)
-            self.H.__sendByte__(CP.SQR1_PATTERN)
-            self.H.__sendInt__(len(timing_array))
-            time.sleep(sum(timing_array) * 1e-6)  # Sleep for the whole duration
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+
+        self.H.__sendByte__(CP.WAVEGEN)
+        self.H.__sendByte__(CP.SQR1_PATTERN)
+        self.H.__sendInt__(len(timing_array))
+        time.sleep(sum(timing_array) * 1e-6)  # Sleep for the whole duration
+        self.H.__get_ack__()
+
         return True
 
     def sqr2(self, freq, duty_cycle):
@@ -3449,17 +3217,15 @@ class ScienceLab():
         if prescaler == 4 or wavelength == 0:
             self.__print__('out of range')
             return 0
-        try:
-            high_time = wavelength * duty_cycle / 100.
-            self.__print__(wavelength, high_time, prescaler)
-            self.H.__sendByte__(CP.WAVEGEN)
-            self.H.__sendByte__(CP.SET_SQR2)
-            self.H.__sendInt__(int(round(wavelength)))
-            self.H.__sendInt__(int(round(high_time)))
-            self.H.__sendByte__(prescaler)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+
+        high_time = wavelength * duty_cycle / 100.
+        self.__print__(wavelength, high_time, prescaler)
+        self.H.__sendByte__(CP.WAVEGEN)
+        self.H.__sendByte__(CP.SET_SQR2)
+        self.H.__sendInt__(int(round(wavelength)))
+        self.H.__sendInt__(int(round(high_time)))
+        self.H.__sendByte__(prescaler)
+        self.H.__get_ack__()
 
         self.sqrfreq['SQR2'] = 64e6 / wavelength / p[prescaler & 0x3]
         return self.sqrfreq['SQR2']
@@ -3481,17 +3247,15 @@ class ScienceLab():
 		==============  ============================================================================================
 
 		"""
-        try:
-            self.H.__sendByte__(CP.WAVEGEN)
-            self.H.__sendByte__(CP.SET_SQRS)
-            self.H.__sendInt__(wavelength)
-            self.H.__sendInt__(phase)
-            self.H.__sendInt__(high_time1)
-            self.H.__sendInt__(high_time2)
-            self.H.__sendByte__(prescaler)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+
+        self.H.__sendByte__(CP.WAVEGEN)
+        self.H.__sendByte__(CP.SET_SQRS)
+        self.H.__sendInt__(wavelength)
+        self.H.__sendInt__(phase)
+        self.H.__sendInt__(high_time1)
+        self.H.__sendInt__(high_time2)
+        self.H.__sendByte__(prescaler)
+        self.H.__get_ack__()
 
     def sqrPWM(self, freq, h0, p1, h1, p2, h2, p3, h3, **kwargs):
         """
@@ -3543,17 +3307,15 @@ class ScienceLab():
         self.H.__sendByte__(CP.SQR4)
         self.H.__sendInt__(wavelength - 1)
         self.H.__sendInt__(int(wavelength * h0) - 1)
-        try:
-            self.H.__sendInt__(max(0, A1 - 1))
-            self.H.__sendInt__(max(1, B1 - 1))
-            self.H.__sendInt__(max(0, A2 - 1))
-            self.H.__sendInt__(max(1, B2 - 1))
-            self.H.__sendInt__(max(0, A3 - 1))
-            self.H.__sendInt__(max(1, B3 - 1))
-            self.H.__sendByte__(prescaler)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+
+        self.H.__sendInt__(max(0, A1 - 1))
+        self.H.__sendInt__(max(1, B1 - 1))
+        self.H.__sendInt__(max(0, A2 - 1))
+        self.H.__sendInt__(max(1, B2 - 1))
+        self.H.__sendInt__(max(0, A3 - 1))
+        self.H.__sendInt__(max(1, B3 - 1))
+        self.H.__sendByte__(prescaler)
+        self.H.__get_ack__()
 
         for a in ['SQR1', 'SQR2', 'SQR3', 'SQR4']: self.sqrfreq[a] = 64e6 / wavelength / p[prescaler & 0x3]
         return 64e6 / wavelength / p[prescaler & 0x3]
@@ -3585,21 +3347,18 @@ class ScienceLab():
 			0Hz to about 100KHz instead of the original 2MHz.
 
 		"""
-        try:
-            self.H.__sendByte__(CP.WAVEGEN)
-            self.H.__sendByte__(CP.MAP_REFERENCE)
-            chan = 0
-            if 'SQR1' in args: chan |= 1
-            if 'SQR2' in args: chan |= 2
-            if 'SQR3' in args: chan |= 4
-            if 'SQR4' in args: chan |= 8
-            if 'WAVEGEN' in args: chan |= 16
-            self.H.__sendByte__(chan)
-            self.H.__sendByte__(scaler)
-            if 'WAVEGEN' in args: self.DDS_CLOCK = 128e6 / (1 << scaler)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.WAVEGEN)
+        self.H.__sendByte__(CP.MAP_REFERENCE)
+        chan = 0
+        if 'SQR1' in args: chan |= 1
+        if 'SQR2' in args: chan |= 2
+        if 'SQR3' in args: chan |= 4
+        if 'SQR4' in args: chan |= 8
+        if 'WAVEGEN' in args: chan |= 16
+        self.H.__sendByte__(chan)
+        self.H.__sendByte__(scaler)
+        if 'WAVEGEN' in args: self.DDS_CLOCK = 128e6 / (1 << scaler)
+        self.H.__get_ack__()
 
     # -------------------------------------------------------------------------------------------------------------------#
 
@@ -3719,22 +3478,20 @@ class ScienceLab():
         else:
             print('invalid output')
             return
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(pin)
-            self.H.__sendByte__(len(cols) * 3)
-            for col in cols:
-                # R=reverse_bits(int(col[0]));G=reverse_bits(int(col[1]));B=reverse_bits(int(col[2]))
-                R = col[0]
-                G = col[1]
-                B = col[2]
-                self.H.__sendByte__(G)
-                self.H.__sendByte__(R)
-                self.H.__sendByte__(B)
-            # print(col)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(pin)
+        self.H.__sendByte__(len(cols) * 3)
+        for col in cols:
+            # R=reverse_bits(int(col[0]));G=reverse_bits(int(col[1]));B=reverse_bits(int(col[2]))
+            R = col[0]
+            G = col[1]
+            B = col[2]
+            self.H.__sendByte__(G)
+            self.H.__sendByte__(R)
+            self.H.__sendByte__(B)
+        # print(col)
+        self.H.__get_ack__()
 
     # -------------------------------------------------------------------------------------------------------------------#
 
@@ -3754,28 +3511,22 @@ class ScienceLab():
 		address         Address to read from. Refer to PIC24EP64GP204 programming manual
 		==============  ============================================================================================
 		"""
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.READ_PROGRAM_ADDRESS)
-            self.H.__sendInt__(address & 0xFFFF)
-            self.H.__sendInt__((address >> 16) & 0xFFFF)
-            v = self.H.__getInt__()
-            self.H.__get_ack__()
-            return v
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.READ_PROGRAM_ADDRESS)
+        self.H.__sendInt__(address & 0xFFFF)
+        self.H.__sendInt__((address >> 16) & 0xFFFF)
+        v = self.H.__getInt__()
+        self.H.__get_ack__()
+        return v
 
     def device_id(self):
-        try:
-            a = self.read_program_address(0x800FF8)
-            b = self.read_program_address(0x800FFa)
-            c = self.read_program_address(0x800FFc)
-            d = self.read_program_address(0x800FFe)
-            val = d | (c << 16) | (b << 32) | (a << 48)
-            self.__print__(a, b, c, d, hex(val))
-            return val
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        a = self.read_program_address(0x800FF8)
+        b = self.read_program_address(0x800FFa)
+        c = self.read_program_address(0x800FFc)
+        d = self.read_program_address(0x800FFe)
+        val = d | (c << 16) | (b << 32) | (a << 48)
+        self.__print__(a, b, c, d, hex(val))
+        return val
 
     def __write_program_address__(self, address, value):
         """
@@ -3789,15 +3540,12 @@ class ScienceLab():
 						Do Not Screw around with this. It won't work anyway.
 		==============  ============================================================================================
 		"""
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.WRITE_PROGRAM_ADDRESS)
-            self.H.__sendInt__(address & 0xFFFF)
-            self.H.__sendInt__((address >> 16) & 0xFFFF)
-            self.H.__sendInt__(value)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.WRITE_PROGRAM_ADDRESS)
+        self.H.__sendInt__(address & 0xFFFF)
+        self.H.__sendInt__((address >> 16) & 0xFFFF)
+        self.H.__sendInt__(value)
+        self.H.__get_ack__()
 
     def read_data_address(self, address):
         """
@@ -3811,15 +3559,12 @@ class ScienceLab():
 		address         Address to read from.  Refer to PIC24EP64GP204 programming manual|
 		==============  ============================================================================================
 		"""
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.READ_DATA_ADDRESS)
-            self.H.__sendInt__(address & 0xFFFF)
-            v = self.H.__getInt__()
-            self.H.__get_ack__()
-            return v
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.READ_DATA_ADDRESS)
+        self.H.__sendInt__(address & 0xFFFF)
+        v = self.H.__getInt__()
+        self.H.__get_ack__()
+        return v
 
     def __write_data_address__(self, address, value):
         """
@@ -3833,14 +3578,11 @@ class ScienceLab():
 		address         Address to write to.  Refer to PIC24EP64GP204 programming manual|
 		==============  ============================================================================================
 		"""
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.WRITE_DATA_ADDRESS)
-            self.H.__sendInt__(address & 0xFFFF)
-            self.H.__sendInt__(value)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.WRITE_DATA_ADDRESS)
+        self.H.__sendInt__(address & 0xFFFF)
+        self.H.__sendInt__(value)
+        self.H.__get_ack__()
 
     # -------------------------------------------------------------------------------------------------------------------#
 
@@ -3849,13 +3591,10 @@ class ScienceLab():
     # -------------------------------------------------------------------------------------------------------------------#
 
     def __stepperMotor__(self, steps, delay, direction):
-        try:
-            self.H.__sendByte__(CP.NONSTANDARD_IO)
-            self.H.__sendByte__(CP.STEPPER_MOTOR)
-            self.H.__sendInt__((steps << 1) | direction)
-            self.H.__sendInt__(delay)
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NONSTANDARD_IO)
+        self.H.__sendByte__(CP.STEPPER_MOTOR)
+        self.H.__sendInt__((steps << 1) | direction)
+        self.H.__sendInt__(delay)
 
         time.sleep(steps * delay * 1e-3)  # convert mS to S
 
@@ -3914,22 +3653,19 @@ class ScienceLab():
 		==============  ============================================================================================
 
 		"""
-        try:
-            params = (1 << 5) | 2  # continuous waveform.  prescaler 2( 1:64)
-            self.H.__sendByte__(CP.WAVEGEN)
-            self.H.__sendByte__(CP.SQR4)
-            self.H.__sendInt__(10000)  # 10mS wavelength
-            self.H.__sendInt__(750 + int(a1 * 1900 / 180))
-            self.H.__sendInt__(0)
-            self.H.__sendInt__(750 + int(a2 * 1900 / 180))
-            self.H.__sendInt__(0)
-            self.H.__sendInt__(750 + int(a3 * 1900 / 180))
-            self.H.__sendInt__(0)
-            self.H.__sendInt__(750 + int(a4 * 1900 / 180))
-            self.H.__sendByte__(params)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        params = (1 << 5) | 2  # continuous waveform.  prescaler 2( 1:64)
+        self.H.__sendByte__(CP.WAVEGEN)
+        self.H.__sendByte__(CP.SQR4)
+        self.H.__sendInt__(10000)  # 10mS wavelength
+        self.H.__sendInt__(750 + int(a1 * 1900 / 180))
+        self.H.__sendInt__(0)
+        self.H.__sendInt__(750 + int(a2 * 1900 / 180))
+        self.H.__sendInt__(0)
+        self.H.__sendInt__(750 + int(a3 * 1900 / 180))
+        self.H.__sendInt__(0)
+        self.H.__sendInt__(750 + int(a4 * 1900 / 180))
+        self.H.__sendByte__(params)
+        self.H.__get_ack__()
 
     def enableUartPassthrough(self, baudrate, persist=False):
         '''
@@ -3951,16 +3687,13 @@ class ScienceLab():
 						received for a period greater than one second at a time.
 		==============  ============================================================================================
 		'''
-        try:
-            self.H.__sendByte__(CP.PASSTHROUGHS)
-            self.H.__sendByte__(CP.PASS_UART)
-            self.H.__sendByte__(1 if persist else 0)
-            self.H.__sendInt__(int(round(((64e6 / baudrate) / 4) - 1)))
-            self.__print__('BRGVAL:', int(round(((64e6 / baudrate) / 4) - 1)))
-            time.sleep(0.1)
-            self.__print__('junk bytes read:', len(self.H.fd.read(100)))
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.PASSTHROUGHS)
+        self.H.__sendByte__(CP.PASS_UART)
+        self.H.__sendByte__(1 if persist else 0)
+        self.H.__sendInt__(int(round(((64e6 / baudrate) / 4) - 1)))
+        self.__print__('BRGVAL:', int(round(((64e6 / baudrate) / 4) - 1)))
+        time.sleep(0.1)
+        self.__print__('junk bytes read:', len(self.H.fd.read(100)))
 
     def estimateDistance(self):
         '''
@@ -3982,23 +3715,20 @@ class ScienceLab():
 
 		returns 0 upon timeout
 		'''
-        try:
-            self.H.__sendByte__(CP.NONSTANDARD_IO)
-            self.H.__sendByte__(CP.HCSR04_HEADER)
+        self.H.__sendByte__(CP.NONSTANDARD_IO)
+        self.H.__sendByte__(CP.HCSR04_HEADER)
 
-            timeout_msb = int((0.3 * 64e6)) >> 16
-            self.H.__sendInt__(timeout_msb)
+        timeout_msb = int((0.3 * 64e6)) >> 16
+        self.H.__sendInt__(timeout_msb)
 
-            A = self.H.__getLong__()
-            B = self.H.__getLong__()
-            tmt = self.H.__getInt__()
-            self.H.__get_ack__()
-            # self.__print__(A,B)
-            if (tmt >= timeout_msb or B == 0): return 0
-            rtime = lambda t: t / 64e6
-            return 330. * rtime(B - A + 20) / 2.
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        A = self.H.__getLong__()
+        B = self.H.__getLong__()
+        tmt = self.H.__getInt__()
+        self.H.__get_ack__()
+        # self.__print__(A,B)
+        if (tmt >= timeout_msb or B == 0): return 0
+        rtime = lambda t: t / 64e6
+        return 330. * rtime(B - A + 20) / 2.
 
     """
 	def TemperatureAndHumidity(self):
@@ -4006,13 +3736,10 @@ class ScienceLab():
 		init  AM2302.
 		This effort was a waste.  There are better humidity and temperature sensors available which use well documented I2C
 		'''
-		try:
-			self.H.__sendByte__(CP.NONSTANDARD_IO)
-			self.H.__sendByte__(CP.AM2302_HEADER)
+		self.H.__sendByte__(CP.NONSTANDARD_IO)
+		self.H.__sendByte__(CP.AM2302_HEADER)
 
-			self.H.__get_ack__()
-		except Exception as ex:
-			self.raiseException(ex, "Communication Error , Function : "+inspect.currentframe().f_code.co_name)
+		self.H.__get_ack__()
 		self.digital_channels_in_buffer=1
 	"""
 
@@ -4030,82 +3757,58 @@ class ScienceLab():
         res = kwargs.get('resolution', 10)
         tweak = kwargs.get('tweak', 1)
 
-        try:
-            self.H.__sendByte__(CP.NONSTANDARD_IO)
-            self.H.__sendByte__(CP.TCD1304_HEADER)
-            if res == 10:
-                self.H.__sendByte__(self.__calcCHOSA__(channel))  # 10-bit
-            else:
-                self.H.__sendByte__(self.__calcCHOSA__(channel) | 0x80)  # 12-bit
-            self.H.__sendByte__(tweak)  # Tweak the SH low to ICG high space. =tweak*delay
-            self.H.__sendInt__(delay)
-            self.H.__sendInt__(int(SS * 64))
-            self.timebase = SS
-            self.achans[0].set_params(channel=0, length=samples, timebase=self.timebase,
-                                      resolution=12 if res != 10 else 10, source=self.analogInputSources[channel])
-            self.samples = samples
-            self.channels_in_buffer = 1
-            time.sleep(2 * delay * 1e-6)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.NONSTANDARD_IO)
+        self.H.__sendByte__(CP.TCD1304_HEADER)
+        if res == 10:
+            self.H.__sendByte__(self.__calcCHOSA__(channel))  # 10-bit
+        else:
+            self.H.__sendByte__(self.__calcCHOSA__(channel) | 0x80)  # 12-bit
+        self.H.__sendByte__(tweak)  # Tweak the SH low to ICG high space. =tweak*delay
+        self.H.__sendInt__(delay)
+        self.H.__sendInt__(int(SS * 64))
+        self.timebase = SS
+        self.achans[0].set_params(channel=0, length=samples, timebase=self.timebase,
+                                  resolution=12 if res != 10 else 10, source=self.analogInputSources[channel])
+        self.samples = samples
+        self.channels_in_buffer = 1
+        time.sleep(2 * delay * 1e-6)
+        self.H.__get_ack__()
 
     def setUARTBAUD(self, BAUD):
-        try:
-            self.H.__sendByte__(CP.UART_2)
-            self.H.__sendByte__(CP.SET_BAUD)
-            self.H.__sendInt__(int(round(((64e6 / BAUD) / 4) - 1)))
-            self.__print__('BRG2VAL:', int(round(((64e6 / BAUD) / 4) - 1)))
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.UART_2)
+        self.H.__sendByte__(CP.SET_BAUD)
+        self.H.__sendInt__(int(round(((64e6 / BAUD) / 4) - 1)))
+        self.__print__('BRG2VAL:', int(round(((64e6 / BAUD) / 4) - 1)))
+        self.H.__get_ack__()
 
     def writeUART(self, character):
-        try:
-            self.H.__sendByte__(CP.UART_2)
-            self.H.__sendByte__(CP.SEND_BYTE)
-            self.H.__sendByte__(character)
-            self.H.__get_ack__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.UART_2)
+        self.H.__sendByte__(CP.SEND_BYTE)
+        self.H.__sendByte__(character)
+        self.H.__get_ack__()
 
     def readUART(self):
-        try:
-            self.H.__sendByte__(CP.UART_2)
-            self.H.__sendByte__(CP.READ_BYTE)
-            return self.H.__getByte__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.UART_2)
+        self.H.__sendByte__(CP.READ_BYTE)
+        return self.H.__getByte__()
 
     def readUARTStatus(self):
         '''
 		return available bytes in UART buffer
 		'''
-        try:
-            self.H.__sendByte__(CP.UART_2)
-            self.H.__sendByte__(CP.READ_UART2_STATUS)
-            return self.H.__getByte__()
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
+        self.H.__sendByte__(CP.UART_2)
+        self.H.__sendByte__(CP.READ_UART2_STATUS)
+        return self.H.__getByte__()
 
     def readLog(self):
         """
 		read hardware debug log.
 		"""
-        try:
-            self.H.__sendByte__(CP.COMMON)
-            self.H.__sendByte__(CP.READ_LOG)
-            log = self.H.fd.readline().strip()
-            self.H.__get_ack__()
-            return log
-        except Exception as ex:
-            self.raiseException(ex, "Communication Error , Function : " + inspect.currentframe().f_code.co_name)
-
-    def raiseException(self, ex, msg):
-        msg += '\n' + ex.message
-        # self.H.disconnect()
-        raise RuntimeError(msg)
-
+        self.H.__sendByte__(CP.COMMON)
+        self.H.__sendByte__(CP.READ_LOG)
+        log = self.H.fd.readline().strip()
+        self.H.__get_ack__()
+        return log
 
 if __name__ == "__main__":
     print(


### PR DESCRIPTION
This PR removes the custom exception handling discussed in #115. It should not affect normal operation (with one exception, see below).

Additionally, it changes the behavior of ScienceLab.write_bulk_flash() by changing the indentation level if this block:
```
        # verification by readback
        tmp = [ord(a) for a in self.read_bulk_flash(location, len(data))]
        print('Verification done', tmp == data)
        if tmp != data: raise Exception('Verification by readback failed')
```
[In the current version](https://github.com/fossasia/pslab-python/blob/5c03e23d3e21413bf2ce42c545c4b7634584c237/PSL/sciencelab.py#L2963), this block will never be executed because it comes after a `raise` statement. This does not seem intentional, so I fixed it. I have not tested it, but since it does not write anything to the hardware it should be safe.

My IDE also autoremoved some trailing whitespace here and there throughout the code.