### PR TITLE
Revert "Add documentation to Fix permission for make file #88 (#89)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ To set up the development environment, install the packages mentioned in depende
 
 First install sphinx by running following command
 
-    sudo pip install -U Sphinx
+    pip install -U Sphinx
 
 Then go to pslab/docs and run the following command
 
-    $ sudo make html
+    $ make html
 
 ## License
 


### PR DESCRIPTION
This reverts commit 24c57a0b4190af07324ac4780e7d3cbc68cf9a38.

Arbitrarily running `sudo` messes up file permissions. In this case, a
user would no longer be able to access the generated documentation
files. Prefer installing tools through the system package manager
instead.