### PR TITLE
chore: removed python 3.5 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-    - "3.5"
     - "3.6"
     - "3.7"
     - "3.8"


### PR DESCRIPTION
Travis build is failing at Python 3.5 with some flake8 tests. Since we are building for higher versions, the lowest Python 3 version is removed in this PR.