### PR TITLE
Move apply_si_prefix into analyticsClass.py

### DIFF
--- a/PSL/commands_proto.py
+++ b/PSL/commands_proto.py
@@ -1,4 +1,5 @@
-import math, sys, time, struct
+import struct
+
 
 # allows to pack numeric values into byte strings
 Byte = struct.Struct("B")  # size 1
@@ -252,34 +253,6 @@ TEN_BIT = Byte.pack(10)
 TWELVE_BIT = Byte.pack(12)
 
 
-def applySIPrefix(value, unit='', precision=2):
-    neg = False
-    if value < 0.:
-        value *= -1
-        neg = True
-    elif value == 0.:
-        return '0 '  # mantissa & exponnt both 0
-    exponent = int(math.log10(value))
-    if exponent > 0:
-        exponent = (exponent // 3) * 3
-    else:
-        exponent = (-1 * exponent + 3) // 3 * (-3)
-
-    value *= (10 ** (-exponent))
-    if value >= 1000.:
-        value /= 1000.0
-        exponent += 3
-    if neg:
-        value *= -1
-    exponent = int(exponent)
-    PREFIXES = "yzafpnum kMGTPEZY"
-    prefix_levels = (len(PREFIXES) - 1) // 2
-    si_level = exponent // 3
-    if abs(si_level) > prefix_levels:
-        raise ValueError("Exponent out range of available prefixes.")
-    return '%.*f %s%s' % (precision, value, PREFIXES[si_level + prefix_levels], unit)
-
-
 '''
 def reverse_bits(x):
 	return int('{:08b}'.format(x)[::-1], 2)
@@ -311,5 +284,5 @@ def getLx(f1,f2,f3,Ccal):
 	b=(f1/f2)**2
 	c=(2*math.pi*f1)**2
 	return (a-1)*(b-1)/(Ccal*c)
-	
+
 '''

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,50 @@
+import unittest
+
+from PSL import analyticsClass
+
+
+class TestAnalytics(unittest.TestCase):
+    def test_frexp10(self):
+        input_value = 43.0982
+        expected_result = (4.30982, 1)
+        self.assertAlmostEqual(analyticsClass.frexp10(input_value), expected_result)
+
+    def test_apply_si_prefix_rounding(self):
+        input_value = {
+            "value": 7545.230053,
+            "unit": "J",
+        }
+        expected_result = "7.55 kJ"
+        self.assertEqual(analyticsClass.apply_si_prefix(**input_value), expected_result)
+
+    def test_apply_si_prefix_high_precision(self):
+        input_value = {
+            "value": -0.000002000008,
+            "unit": "A",
+            "precision": 6,
+        }
+        expected_result = "-2.000008 µA"
+        self.assertEqual(analyticsClass.apply_si_prefix(**input_value), expected_result)
+
+    def test_apply_si_prefix_low_precision(self):
+        input_value = {
+            "value": -1,
+            "unit": "V",
+            "precision": 0,
+        }
+        expected_result = "-1 V"
+        self.assertEqual(analyticsClass.apply_si_prefix(**input_value), expected_result)
+
+    def test_apply_si_prefix_too_big(self):
+        input_value = {
+            "value": 1e27,
+            "unit": "V",
+        }
+        self.assertRaises(ValueError, analyticsClass.apply_si_prefix, **input_value)
+
+    def test_apply_si_prefix_too_small(self):
+        input_value = {
+            "value": 1e-25,
+            "unit": "V",
+        }
+        self.assertRaises(ValueError, analyticsClass.apply_si_prefix, **input_value)


### PR DESCRIPTION
This is a minor change to move the function apply_si_prefix from commands_proto.py to analyticsClass.py, since the function is only used in the latter module. Additional changes:

- rename from applySIPrefix to apply_si_prefix as per PEP8.
- refactor out part of function to helper function frexp10.
- fix a bug in apply_si_prefix where an extra whitespace would be added before the unit if 1 <= abs(value) < 1000, e.g. `apply_si_prefix(1, "V")` would yield '1.00&nbsp; V' instead of '1.00 V'.
- the `unit` argument is no longer optional.
- docstrings added.
- unittests added.

This change does not break the desktop app on my end, please verify.