### PR TITLE
Install udev rules with correct filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,4 @@ clean:
 install:
 	python3 setup.py install
 	mkdir -p $(DESTDIR)/lib/udev/rules.d
-	install -m 644 99-pslab.rules $(DESTDIR)/lib/udev/rules.d/99-pslab
+	install -m 644 99-pslab.rules $(DESTDIR)/lib/udev/rules.d/99-pslab.rules


### PR DESCRIPTION
See #123 
I believe `make install` currently misnames the installed udev rules for pslab, resulting in udev ignoring them. After chaning the filename from 99-pslab to 99-pslab.rules, I no longer need to be a member of the dialout group to communicate with the device.