### PR TITLE
Simplified the I2C API

### DIFF
--- a/PSL/Peripherals.py
+++ b/PSL/Peripherals.py
@@ -284,16 +284,16 @@ class I2CSlave():
         return vals
 
     def simple_read_byte(self):
-        vals = self.simpleRead(1)
+        vals = self.simple_read(1)
         return vals[0]
 
     def simple_read_int(self):
-        vals = self.simpleRead(2)
+        vals = self.simple_read(2)
         bytes_ = bytearray(vals)
         return CP.ShortInt.unpack(bytes_)[0]
 
     def simple_read_long(self):
-        vals = self.simpleRead(4)
+        vals = self.simple_read(4)
         bytes_ = bytearray(vals)
         return CP.Integer.unpack(bytes_)[0]
 
@@ -312,18 +312,18 @@ class I2CSlave():
             return False
 
     def read_bulk_byte(self, register_address):
-        data = self.readBulk(register_address, 1)
+        data = self.read_bulk(register_address, 1)
         if data:
             return data[0]
 
     def read_bulk_int(self, register_address):
-        data = self.readBulk(register_address, 2)
+        data = self.read_bulk(register_address, 2)
         if data:
             bytes_ = bytearray(data)
             return CP.ShortInt.unpack(bytes_)[0]
 
     def read_bulk_long(self, register_address):
-        data = self.readBulk(register_address, 4)
+        data = self.read_bulk(register_address, 4)
         if data:
             bytes_ = bytearray(data)
             return CP.Integer.unpack(bytes_)[0]
@@ -528,55 +528,55 @@ class I2C(I2CMaster, I2CSlave): # for backwards compatibility
         I2CSlave.__init__(self, H, None)
         warn('I2C is deprecated; use I2CMaster and I2CSlave', DeprecationWarning)
 
-    def start(self, address, rw): # pylint: disable=arguments-differ 
+    def start(self, address, rw): # pylint: disable=arguments-differ
         self.address = address
         return super().start(rw)
 
-    def restart(self, address, rw): # pylint: disable=arguments-differ 
+    def restart(self, address, rw): # pylint: disable=arguments-differ
         self.address = address
         return super().restart(rw)
 
-    def simpleRead(self, address, numbytes): # pylint: disable=arguments-differ 
+    def simpleRead(self, address, numbytes): # pylint: disable=arguments-differ
         self.address = address
         return super().simple_read(numbytes)
 
-    def simple_read_byte(self, address): # pylint: disable=arguments-differ 
+    def simple_read_byte(self, address): # pylint: disable=arguments-differ
         self.address = address
         return super().simple_read_byte()
 
-    def simple_read_int(self, address): # pylint: disable=arguments-differ 
+    def simple_read_int(self, address): # pylint: disable=arguments-differ
         self.address = address
         return super().simple_read_int()
 
-    def simple_read_long(self, address): # pylint: disable=arguments-differ 
+    def simple_read_long(self, address): # pylint: disable=arguments-differ
         self.address = address
         return super().simple_read_long()
 
-    def readBulk(self, device_address, register_address, bytes_to_read): # pylint: disable=arguments-differ 
+    def readBulk(self, device_address, register_address, bytes_to_read): # pylint: disable=arguments-differ
         self.address = device_address
         return super().read_bulk(register_address, bytes_to_read)
 
-    def read_bulk_byte(self, device_address, register_address): # pylint: disable=arguments-differ 
+    def read_bulk_byte(self, device_address, register_address): # pylint: disable=arguments-differ
         self.address = device_address
         return super().read_bulk_byte(register_address)
 
-    def read_bulk_int(self, device_address, register_address): # pylint: disable=arguments-differ 
+    def read_bulk_int(self, device_address, register_address): # pylint: disable=arguments-differ
         self.address = device_address
         return super().read_bulk_int(register_address)
 
-    def read_bulk_long(self, device_address, register_address): # pylint: disable=arguments-differ 
+    def read_bulk_long(self, device_address, register_address): # pylint: disable=arguments-differ
         self.address = device_address
         return super().read_bulk_long(register_address)
 
-    def writeBulk(self, device_address, bytestream): # pylint: disable=arguments-differ 
+    def writeBulk(self, device_address, bytestream): # pylint: disable=arguments-differ
         self.address = device_address
         return super().write_bulk(bytestream)
 
-    def __captureStart__(self, address, location, sample_length, total_samples, tg): # pylint: disable=arguments-differ 
+    def __captureStart__(self, address, location, sample_length, total_samples, tg): # pylint: disable=arguments-differ
         self.address = address
         return super().__captureStart__(location, sample_length, total_samples, tg)
 
-    def capture(self, address, location, sample_length, total_samples, tg, *args): # pylint: disable=arguments-differ 
+    def capture(self, address, location, sample_length, total_samples, tg, *args): # pylint: disable=arguments-differ
         self.address = address
         return super().capture(location, sample_length, total_samples, tg, *args)
 

--- a/PSL/Peripherals.py
+++ b/PSL/Peripherals.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import PSL.commands_proto as CP
 import numpy as np
 import time
+from functools import partial
 
 
 class I2C():
@@ -39,11 +40,20 @@ class I2C():
     tg = 100
     MAX_SAMPLES = 10000
 
-    def __init__(self, H):
+    def __init__(self, H, address=None):
         self.H = H
         from PSL import sensorlist
         self.SENSORS = sensorlist.sensors
         self.buff = np.zeros(10000)
+
+        if address is not None:
+            self.start = partial(self.start, address)
+            self.restart = partial(self.restart, address)
+            self.simpleRead = partial(self.simpleRead, address)
+            self.readBulk = partial(self.readBulk, address)
+            self.writeBulk = partial(self.writeBulk, address)
+            self.__captureStart__ = partial(self.__captureStart__, address)
+            self.capture = partial(self.capture, address)
 
     def init(self):
         self.H.__sendByte__(CP.I2C_HEADER)
@@ -232,7 +242,7 @@ class I2C():
         """
         data = []
 
-        for a in range(length - 1):
+        for _ in range(length - 1):
             self.H.__sendByte__(CP.I2C_HEADER)
             self.H.__sendByte__(CP.I2C_READ_MORE)
             data.append(self.H.__getByte__())

--- a/PSL/Peripherals.py
+++ b/PSL/Peripherals.py
@@ -55,6 +55,13 @@ class I2C():
             self.__captureStart__ = partial(self.__captureStart__, address)
             self.capture = partial(self.capture, address)
 
+            self.simpleRead_byte = partial(self.simpleRead_byte, address)
+            self.simpleRead_word = partial(self.simpleRead_word, address)
+            self.simpleRead_dword = partial(self.simpleRead_dword, address)
+            self.readBulk_byte = partial(self.readBulk_byte, address)
+            self.readBulk_word = partial(self.readBulk_word, address)
+            self.readBulk_dword = partial(self.readBulk_dword, address)
+
     def init(self):
         self.H.__sendByte__(CP.I2C_HEADER)
         self.H.__sendByte__(CP.I2C_INIT)
@@ -227,6 +234,20 @@ class I2C():
         vals = self.read(numbytes)
         return vals
 
+    def simpleRead_byte(self, addr):
+        vals = self.simpleRead(addr, 1)
+        return vals[0]
+
+    def simpleRead_word(self, addr):
+        vals = self.simpleRead(addr, 2)
+        bytes_ = bytearray(vals)
+        return CP.ShortInt.unpack(bytes_)[0]
+
+    def simpleRead_dword(self, addr):
+        vals = self.simpleRead(addr, 4)
+        bytes_ = bytearray(vals)
+        return CP.Integer.unpack(bytes_)[0]
+
     def read(self, length):
         """
         Reads a fixed number of data bytes from I2C device. Fetches length-1 bytes with acknowledge bits for each, +1 byte
@@ -288,6 +309,23 @@ class I2C():
         except:
             print('Transaction failed')
             return False
+
+    def readBulk_byte(self, device_address, register_address):
+        data = self.readBulk(device_address, register_address, 1)
+        if data:
+            return data[0]
+
+    def readBulk_word(self, device_address, register_address):
+        data = self.readBulk(device_address, register_address, 2)
+        if data:
+            bytes_ = bytearray(data)
+            return CP.ShortInt.unpack(bytes_)[0]
+
+    def readBulk_dword(self, device_address, register_address):
+        data = self.readBulk(device_address, register_address, 4)
+        if data:
+            bytes_ = bytearray(data)
+            return CP.Integer.unpack(bytes_)[0]
 
     def writeBulk(self, device_address, bytestream):
         """

--- a/PSL/Peripherals.py
+++ b/PSL/Peripherals.py
@@ -267,7 +267,7 @@ class I2CSlave():
         self.H.__get_ack__()
         return val
 
-    def simpleRead(self, numbytes):
+    def simple_read(self, numbytes):
         """
         Read bytes from I2C slave without first transmitting the read location.
 
@@ -297,7 +297,7 @@ class I2CSlave():
         bytes_ = bytearray(vals)
         return CP.Integer.unpack(bytes_)[0]
 
-    def readBulk(self, register_address, bytes_to_read):
+    def read_bulk(self, register_address, bytes_to_read):
         self.H.__sendByte__(CP.I2C_HEADER)
         self.H.__sendByte__(CP.I2C_READ_BULK)
         self.H.__sendByte__(self.address)
@@ -328,7 +328,7 @@ class I2CSlave():
             bytes_ = bytearray(data)
             return CP.Integer.unpack(bytes_)[0]
 
-    def writeBulk(self, bytestream):
+    def write_bulk(self, bytestream):
         """
         write bytes to I2C slave
 
@@ -528,55 +528,55 @@ class I2C(I2CMaster, I2CSlave): # for backwards compatibility
         I2CSlave.__init__(self, H, None)
         warn('I2C is deprecated; use I2CMaster and I2CSlave', DeprecationWarning)
 
-    def start(self, address, rw): # nosec
+    def start(self, address, rw): # pylint: disable=arguments-differ 
         self.address = address
         return super().start(rw)
 
-    def restart(self, address, rw): # nosec
+    def restart(self, address, rw): # pylint: disable=arguments-differ 
         self.address = address
         return super().restart(rw)
 
-    def simpleRead(self, address, numbytes): # nosec
+    def simpleRead(self, address, numbytes): # pylint: disable=arguments-differ 
         self.address = address
-        return super().simpleRead(numbytes)
+        return super().simple_read(numbytes)
 
-    def simple_read_byte(self, address): # nosec
+    def simple_read_byte(self, address): # pylint: disable=arguments-differ 
         self.address = address
         return super().simple_read_byte()
-    
-    def simple_read_int(self, address): # nosec
+
+    def simple_read_int(self, address): # pylint: disable=arguments-differ 
         self.address = address
         return super().simple_read_int()
 
-    def simple_read_long(self, address): # nosec
+    def simple_read_long(self, address): # pylint: disable=arguments-differ 
         self.address = address
         return super().simple_read_long()
 
-    def readBulk(self, device_address, register_address, bytes_to_read): # nosec
+    def readBulk(self, device_address, register_address, bytes_to_read): # pylint: disable=arguments-differ 
         self.address = device_address
-        return super().readBulk(register_address, bytes_to_read)
+        return super().read_bulk(register_address, bytes_to_read)
 
-    def read_bulk_byte(self, device_address, register_address): # nosec
+    def read_bulk_byte(self, device_address, register_address): # pylint: disable=arguments-differ 
         self.address = device_address
         return super().read_bulk_byte(register_address)
 
-    def read_bulk_int(self, device_address, register_address): # nosec
+    def read_bulk_int(self, device_address, register_address): # pylint: disable=arguments-differ 
         self.address = device_address
         return super().read_bulk_int(register_address)
 
-    def read_bulk_long(self, device_address, register_address): # nosec
+    def read_bulk_long(self, device_address, register_address): # pylint: disable=arguments-differ 
         self.address = device_address
         return super().read_bulk_long(register_address)
 
-    def writeBulk(self, device_address, bytestream): # nosec
+    def writeBulk(self, device_address, bytestream): # pylint: disable=arguments-differ 
         self.address = device_address
-        return super().writeBulk(bytestream)
+        return super().write_bulk(bytestream)
 
-    def __captureStart__(self, address, location, sample_length, total_samples, tg): # nosec
+    def __captureStart__(self, address, location, sample_length, total_samples, tg): # pylint: disable=arguments-differ 
         self.address = address
         return super().__captureStart__(location, sample_length, total_samples, tg)
 
-    def capture(self, address, location, sample_length, total_samples, tg, *args): # nosec
+    def capture(self, address, location, sample_length, total_samples, tg, *args): # pylint: disable=arguments-differ 
         self.address = address
         return super().capture(location, sample_length, total_samples, tg, *args)
 

--- a/PSL/Peripherals.py
+++ b/PSL/Peripherals.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from warnings import warn
 import PSL.commands_proto as CP
 import numpy as np
 import time
@@ -394,7 +395,7 @@ class I2CSlave():
         '''
         Fetch data acquired by the I2C scope. refer to :func:`__captureStart__`
         '''
-        total_int_samples = self.total_bytes / 2
+        total_int_samples = self.total_bytes // 2
         DATA_SPLITTING = 500
         print('fetchin samples : ', total_int_samples, '   split', DATA_SPLITTING)
         data = b''
@@ -525,56 +526,57 @@ class I2C(I2CMaster, I2CSlave): # for backwards compatibility
     def __init__(self, H):
         I2CMaster.__init__(self, H)
         I2CSlave.__init__(self, H, None)
+        warn('I2C is deprecated; use I2CMaster and I2CSlave', DeprecationWarning)
 
-    def start(self, address, rw):
+    def start(self, address, rw): # nosec
         self.address = address
         return super().start(rw)
-    
-    def restart(self, address, rw):
+
+    def restart(self, address, rw): # nosec
         self.address = address
         return super().restart(rw)
 
-    def simpleRead(self, address, numbytes):
+    def simpleRead(self, address, numbytes): # nosec
         self.address = address
         return super().simpleRead(numbytes)
 
-    def simple_read_byte(self, address):
+    def simple_read_byte(self, address): # nosec
         self.address = address
         return super().simple_read_byte()
     
-    def simple_read_int(self, address):
+    def simple_read_int(self, address): # nosec
         self.address = address
         return super().simple_read_int()
 
-    def simple_read_long(self, address):
+    def simple_read_long(self, address): # nosec
         self.address = address
         return super().simple_read_long()
 
-    def readBulk(self, device_address, register_address, bytes_to_read):
+    def readBulk(self, device_address, register_address, bytes_to_read): # nosec
         self.address = device_address
         return super().readBulk(register_address, bytes_to_read)
 
-    def read_bulk_byte(self, device_address, register_address):
+    def read_bulk_byte(self, device_address, register_address): # nosec
         self.address = device_address
         return super().read_bulk_byte(register_address)
 
-    def read_bulk_int(self, device_address, register_address):
+    def read_bulk_int(self, device_address, register_address): # nosec
         self.address = device_address
         return super().read_bulk_int(register_address)
 
-    def read_bulk_long(self, device_address, register_address):
+    def read_bulk_long(self, device_address, register_address): # nosec
         self.address = device_address
         return super().read_bulk_long(register_address)
 
-    def writeBulk(self, device_address, bytestream):
+    def writeBulk(self, device_address, bytestream): # nosec
         self.address = device_address
         return super().writeBulk(bytestream)
 
-    def __captureStart__(self, address, location, sample_length, total_samples, tg):
+    def __captureStart__(self, address, location, sample_length, total_samples, tg): # nosec
         self.address = address
         return super().__captureStart__(location, sample_length, total_samples, tg)
 
-    def capture(self, address, location, sample_length, total_samples, tg, *args):
+    def capture(self, address, location, sample_length, total_samples, tg, *args): # nosec
         self.address = address
         return super().capture(location, sample_length, total_samples, tg, *args)
 

--- a/tests/test_peripherals_i2c.py
+++ b/tests/test_peripherals_i2c.py
@@ -195,7 +195,7 @@ def test_simple_read(slave):
     bytes_read = [CP.ACKNOWLEDGE] * 4*2
     bytes_read[::2] = [b'd', b'a', b't', b'a']
     slave.H.interface.read.side_effect = [CP.ACKNOWLEDGE] + bytes_read
-    assert slave.simpleRead(4) == list(b'data')
+    assert slave.simple_read(4) == list(b'data')
 
     calls = START_READ + ACK
     calls += (READ_MORE + [H_interface.read(1)] + ACK)*3
@@ -233,7 +233,7 @@ def test_simple_read_long(slave):
 
 def test_read_bulk(slave):
     slave.H.interface.read.side_effect = [b'data', CP.ACKNOWLEDGE]
-    assert slave.readBulk(REGISTER_ADDRESS, 4) == list(b'data')
+    assert slave.read_bulk(REGISTER_ADDRESS, 4) == list(b'data')
 
     calls = READ_BULK + [H_interface.write(CP.Byte.pack(4))]
     calls += [H_interface.read(4)] + ACK
@@ -264,7 +264,7 @@ def test_read_bulk_long(slave):
     assert slave.H.interface.method_calls == calls
 
 def test_write_bulk(slave):
-    slave.writeBulk(b'data')
+    slave.write_bulk(b'data')
 
     calls = WRITE_BULK + [H_interface.write(CP.Byte.pack(4))]
     calls += list(map(H_interface.write, [b'd',b'a',b't',b'a']))

--- a/tests/test_peripherals_i2c.py
+++ b/tests/test_peripherals_i2c.py
@@ -2,14 +2,16 @@ from unittest.mock import Mock, call as H_interface
 import pytest
 
 from PSL import commands_proto as CP
-from PSL.Peripherals import I2CMaster, I2CSlave, I2C
+from PSL.Peripherals import I2CMaster, I2CSlave
 from PSL.packet_handler import Handler
 
 ADDRESS = 0X52
 REGISTER_ADDRESS = 0x06
 
 class MockHandler(Handler):
-    def connect(self, *args, **kwargs):
+    def connect(
+        self, port: str = None, baudrate: int = 1000000, timeout: float = 1.0,
+    ):
         pass
 
 @pytest.fixture

--- a/tests/test_peripherals_i2c.py
+++ b/tests/test_peripherals_i2c.py
@@ -1,0 +1,273 @@
+from unittest.mock import Mock, call as H_interface
+import pytest
+
+from PSL import commands_proto as CP
+from PSL.Peripherals import I2CMaster, I2CSlave, I2C
+from PSL.packet_handler import Handler
+
+ADDRESS = 0X52
+REGISTER_ADDRESS = 0x06
+
+class MockHandler(Handler):
+    def connect(self, *args, **kwargs):
+        pass
+
+@pytest.fixture
+def handler():
+    mock_handler = MockHandler()
+    mock_handler.interface = Mock()
+    mock_handler.interface.read.return_value=CP.ACKNOWLEDGE
+    mock_handler.interface.write.return_value=None
+    return mock_handler
+
+@pytest.fixture
+def master(handler):
+    return I2CMaster(handler)
+
+@pytest.fixture
+def slave(handler):
+    return I2CSlave(handler, ADDRESS)
+
+class Response:
+    def __init__(self, interface, responses, default):
+        self.interface = interface # mocked
+        self.responses = responses
+        self.default = default
+    def __call__(self, request):
+        if request in self.responses:
+            self.interface.read.return_value = self.responses[request]
+        else:
+            self.interface.read.return_value = self.default
+
+
+CONFIG = list(map(H_interface.write,[
+    CP.I2C_HEADER,
+    CP.I2C_CONFIG,
+]))
+
+ACK = [H_interface.read(1)]
+
+def test_config_frequency(master):
+    MAX_BRGVAL = master.MAX_BRGVAL
+
+    # <= MAX_BRGVAL
+    BRGVAL = MAX_BRGVAL - 1
+    freq = round(1.0/((BRGVAL+1.0)/64e6+1.0/1e7))
+    master.config(freq, verbose=True)
+    calls = CONFIG + [H_interface.write(CP.ShortInt.pack(BRGVAL))] + ACK
+    assert master.H.interface.method_calls == calls
+
+def test_config_low_frequency(master, capsys):
+    MAX_BRGVAL = master.MAX_BRGVAL
+
+    # > MAX_BRGVAL
+    BRGVAL = MAX_BRGVAL + 1
+    freq = round(1.0/((BRGVAL+1.0)/64e6+1.0/1e7))
+    master.config(freq, verbose=True)
+    calls = CONFIG + [H_interface.write(CP.ShortInt.pack(MAX_BRGVAL))] + ACK
+    assert master.H.interface.method_calls == calls
+    captured = capsys.readouterr()
+    assert captured.out == f'Frequency too low. Setting to : {1/((MAX_BRGVAL+1.0)/64e6+1.0/1e7)}\n'
+
+def test_scan(master):
+    address = CP.Byte.pack(((ADDRESS << 1) | 0) & 0xFF)
+    interface = master.H.interface
+    success = CP.Byte.pack(1)
+    responses = {address : success}
+
+    interface.write.side_effect = Response(interface, responses, CP.ACKNOWLEDGE)
+    assert master.scan() == [ADDRESS]
+
+
+START_READ = list(map(H_interface.write,[
+    CP.I2C_HEADER,
+    CP.I2C_START,
+    CP.Byte.pack(((ADDRESS << 1) | 1) & 0xFF),
+]))
+
+START_WRITE = list(map(H_interface.write,[
+    CP.I2C_HEADER,
+    CP.I2C_START,
+    CP.Byte.pack(((ADDRESS << 1) | 0) & 0xFF),
+]))
+
+STOP = list(map(H_interface.write,[
+    CP.I2C_HEADER,
+    CP.I2C_STOP,
+]))
+
+SEND = list(map(H_interface.write,[
+    CP.I2C_HEADER,
+    CP.I2C_SEND,
+]))
+
+SEND_BURST = list(map(H_interface.write,[
+    CP.I2C_HEADER,
+    CP.I2C_SEND_BURST,
+]))
+
+RESTART_READ = list(map(H_interface.write,[
+    CP.I2C_HEADER,
+    CP.I2C_RESTART,
+    CP.Byte.pack(((ADDRESS << 1) | 1) & 0xFF),
+]))
+
+RESTART_WRITE = list(map(H_interface.write,[
+    CP.I2C_HEADER,
+    CP.I2C_RESTART,
+    CP.Byte.pack(((ADDRESS << 1) | 0) & 0xFF),
+]))
+
+READ_MORE = list(map(H_interface.write,[
+    CP.I2C_HEADER,
+    CP.I2C_READ_MORE,
+]))
+
+READ_END = list(map(H_interface.write,[
+    CP.I2C_HEADER,
+    CP.I2C_READ_END,
+]))
+
+READ_BULK = list(map(H_interface.write,[
+    CP.I2C_HEADER,
+    CP.I2C_READ_BULK,
+    CP.Byte.pack(ADDRESS),
+    CP.Byte.pack(REGISTER_ADDRESS),
+]))
+
+WRITE_BULK = list(map(H_interface.write,[
+    CP.I2C_HEADER,
+    CP.I2C_WRITE_BULK,
+    CP.Byte.pack(ADDRESS),
+]))
+
+CAPTURE_START = list(map(H_interface.write,[
+    CP.I2C_HEADER,
+    CP.I2C_START_SCOPE,
+    CP.Byte.pack(ADDRESS),
+    CP.Byte.pack(REGISTER_ADDRESS),
+]))
+
+def test_send(slave):
+    slave.start(0)
+    slave.send(0xFF)
+    slave.stop()
+    calls = START_WRITE + ACK
+    calls += SEND + [H_interface.write(CP.Byte.pack(0xFF))] + ACK
+    calls += STOP + ACK
+    assert slave.H.interface.method_calls == calls
+
+def test_send_burst(slave):
+    slave.start(0)
+    slave.send_burst(0xFF)
+    slave.stop()
+    calls = START_WRITE + ACK
+    calls += SEND_BURST + [H_interface.write(CP.Byte.pack(0xFF))]
+    calls += STOP + ACK
+    assert slave.H.interface.method_calls == calls
+
+def test_restart(slave):
+    slave.start(1)
+    slave.restart(0)
+    slave.stop()
+    calls = START_READ + ACK
+    calls += RESTART_WRITE + ACK
+    calls += STOP + ACK
+    assert slave.H.interface.method_calls == calls
+
+def test_read(slave):
+    slave.start(1)
+    bytes_read = [CP.ACKNOWLEDGE] * 4*2
+    bytes_read[::2] = [b'd', b'a', b't', b'a']
+    slave.H.interface.read.side_effect = bytes_read + [CP.ACKNOWLEDGE]
+    assert slave.read(4) == list(b'data')
+    slave.stop()
+
+    calls = START_READ + ACK
+    calls += (READ_MORE + [H_interface.read(1)] + ACK)*3
+    calls += READ_END + [H_interface.read(1)] + ACK
+    calls += STOP + ACK
+    assert slave.H.interface.method_calls == calls
+
+def test_simple_read(slave):
+    bytes_read = [CP.ACKNOWLEDGE] * 4*2
+    bytes_read[::2] = [b'd', b'a', b't', b'a']
+    slave.H.interface.read.side_effect = [CP.ACKNOWLEDGE] + bytes_read
+    assert slave.simpleRead(4) == list(b'data')
+
+    calls = START_READ + ACK
+    calls += (READ_MORE + [H_interface.read(1)] + ACK)*3
+    calls += READ_END + [H_interface.read(1)] + ACK
+    assert slave.H.interface.method_calls == calls
+
+def test_simple_read_byte(slave):
+    bytes_read = [b'\xFF', CP.ACKNOWLEDGE]
+    slave.H.interface.read.side_effect = [CP.ACKNOWLEDGE] + bytes_read
+    assert slave.simple_read_byte() == 0xFF
+
+    calls = START_READ + ACK
+    calls += READ_END + [H_interface.read(1)] + ACK
+    assert slave.H.interface.method_calls == calls
+
+def test_simple_read_int(slave):
+    bytes_read = [b'\xFF', CP.ACKNOWLEDGE] * 2
+    slave.H.interface.read.side_effect = [CP.ACKNOWLEDGE] + bytes_read
+    assert slave.simple_read_int() == 0xFFFF
+
+    calls = START_READ + ACK
+    calls += (READ_MORE + [H_interface.read(1)] + ACK)*1
+    calls += READ_END + [H_interface.read(1)] + ACK
+    assert slave.H.interface.method_calls == calls
+
+def test_simple_read_long(slave):
+    bytes_read = [b'\xFF', CP.ACKNOWLEDGE] * 4
+    slave.H.interface.read.side_effect = [CP.ACKNOWLEDGE] + bytes_read
+    assert slave.simple_read_long() == 0xFFFFFFFF
+
+    calls = START_READ + ACK
+    calls += (READ_MORE + [H_interface.read(1)] + ACK)*3
+    calls += READ_END + [H_interface.read(1)] + ACK
+    assert slave.H.interface.method_calls == calls
+
+def test_read_bulk(slave):
+    slave.H.interface.read.side_effect = [b'data', CP.ACKNOWLEDGE]
+    assert slave.readBulk(REGISTER_ADDRESS, 4) == list(b'data')
+
+    calls = READ_BULK + [H_interface.write(CP.Byte.pack(4))]
+    calls += [H_interface.read(4)] + ACK
+    assert slave.H.interface.method_calls == calls
+
+def test_read_bulk_byte(slave):
+    slave.H.interface.read.side_effect = [b'\xFF', CP.ACKNOWLEDGE]
+    assert slave.read_bulk_byte(REGISTER_ADDRESS) == 0xFF
+
+    calls = READ_BULK + [H_interface.write(CP.Byte.pack(1))]
+    calls += [H_interface.read(1)] + ACK
+    assert slave.H.interface.method_calls == calls
+
+def test_read_bulk_int(slave):
+    slave.H.interface.read.side_effect = [b'\xFF'*2, CP.ACKNOWLEDGE]
+    assert slave.read_bulk_int(REGISTER_ADDRESS) == 0xFFFF
+
+    calls = READ_BULK + [H_interface.write(CP.Byte.pack(2))]
+    calls += [H_interface.read(2)] + ACK
+    assert slave.H.interface.method_calls == calls
+
+def test_read_bulk_long(slave):
+    slave.H.interface.read.side_effect = [b'\xFF'*4, CP.ACKNOWLEDGE]
+    assert slave.read_bulk_long(REGISTER_ADDRESS) == 0xFFFFFFFF
+
+    calls = READ_BULK + [H_interface.write(CP.Byte.pack(4))]
+    calls += [H_interface.read(4)] + ACK
+    assert slave.H.interface.method_calls == calls
+
+def test_write_bulk(slave):
+    slave.writeBulk(b'data')
+
+    calls = WRITE_BULK + [H_interface.write(CP.Byte.pack(4))]
+    calls += list(map(H_interface.write, [b'd',b'a',b't',b'a']))
+    calls += ACK
+    assert slave.H.interface.method_calls == calls
+
+def test_capture(slave):
+    pass #TODO


### PR DESCRIPTION
closes  #136

* [X] Currently, we need to pass the I2C address for every API call to the I2C bus. It would be great to have a simpler API where you could instead initialize a class with the address and keep using the object for further operations.

* [X] When reading a single byte, we need to take it from an array for each read. A simpler read_single would be great, or maybe read_16 etc in addition for two bytes at once.

### changes
1. `I2C` -> `I2CMaster` and `I2CSlave`

### added methods
1.  `simple_read_byte()` `simple_read_int()` `simple_read_long()`
2. `read_bulk_byte()` `read_bulk_int()` `read_bulk_long()`