### PR TITLE
Add dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     author="FOSSASIA PSLab Developers",
     author_email="pslab-fossasia@googlegroups.com",
     url="https://pslab.io/",
-    install_requires=["numpy>=1.16.3."],
+    install_requires=["numpy>=1.16.3", "pyserial>=3.4", "scipy>=1.3.0"],
     packages=find_packages(exclude=("tests",)),
     package_data={
         "": [


### PR DESCRIPTION
Required for `pip install` to work correctly.