### PR TITLE
Fixed pslab cli entry point

### DIFF
--- a/pslab/cli.py
+++ b/pslab/cli.py
@@ -2,7 +2,7 @@
 
 Example
 -------
->>> from PSL import cli
+>>> from pslab import cli
 >>> parser, subparser = cli.get_parser()
 >>> cli.add_collect_args(subparser)
 >>> cli.add_wave_args(subparser)

--- a/pslab/cli.py
+++ b/pslab/cli.py
@@ -99,7 +99,6 @@ def oscilloscope(
     active_channels = ([scope._channel_one_map] + scope._CH234)[:channels]
     xy = [np.array([]) for _ in range(1 + channels)]
 
-    total_ts = 0
     while duration > 0:
         if duration >= max_duration:
             samples = max_samples
@@ -107,12 +106,8 @@ def oscilloscope(
             samples = round((duration * 1e6) / min_timegap)
 
         st = time.time()
-        new_xy = scope.capture(channels, samples, min_timegap)
-        new_xy[0] += total_ts * 1e6
-        xy = np.append(xy, new_xy, axis=1)
-        ts = time.time() - st
-        total_ts += ts
-        duration -= ts
+        xy = np.append(xy, scope.capture(channels, samples, min_timegap), axis=1)
+        duration -= time.time() - st
 
     return ["Timestamp"] + active_channels, xy
 

--- a/pslab/cli.py
+++ b/pslab/cli.py
@@ -99,6 +99,7 @@ def oscilloscope(
     active_channels = ([scope._channel_one_map] + scope._CH234)[:channels]
     xy = [np.array([]) for _ in range(1 + channels)]
 
+    total_ts = 0
     while duration > 0:
         if duration >= max_duration:
             samples = max_samples
@@ -106,8 +107,12 @@ def oscilloscope(
             samples = round((duration * 1e6) / min_timegap)
 
         st = time.time()
-        xy = np.append(xy, scope.capture(channels, samples, min_timegap), axis=1)
-        duration -= time.time() - st
+        new_xy = scope.capture(channels, samples, min_timegap)
+        new_xy[0] += total_ts * 1e6
+        xy = np.append(xy, new_xy, axis=1)
+        ts = time.time() - st
+        total_ts += ts
+        duration -= ts
 
     return ["Timestamp"] + active_channels, xy
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
         ]
     },
     entry_points = {
-        'console_scripts': ['pslab=PSL.cli:cmdline'],
+        'console_scripts': ['pslab=pslab.cli:cmdline'],
     },
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
1. Fixed pslab cli entry point, according to `PSL -> pslab` [commit](https://github.com/fossasia/pslab-python/commit/2ff4ed360c945c50f4a8f9eb677cdbe099fe61ee).  
2. <del> Fixed incorrect timestamps in `pslab.cli.oscilloscope`. which previously return repeated timestamps instead of continues. </del>