### PR TITLE
Support multiple devices (closes #170)

### DIFF
--- a/pslab/sciencelab.py
+++ b/pslab/sciencelab.py
@@ -32,8 +32,13 @@ class ScienceLab(SerialHandler):
     nrf : pslab.peripherals.NRF24L01
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(
+        self,
+        port: str = None,
+        baudrate: int = 1000000,
+        timeout: float = 1.0,
+    ):
+        super().__init__(port, baudrate, timeout)
         self.logic_analyzer = LogicAnalyzer(device=self)
         self.oscilloscope = Oscilloscope(device=self)
         self.waveform_generator = WaveformGenerator(device=self)
@@ -210,10 +215,10 @@ class ScienceLab(SerialHandler):
         return data
 
     def _device_id(self):
-        a = self.read_program_address(0x800FF8)
-        b = self.read_program_address(0x800FFA)
-        c = self.read_program_address(0x800FFC)
-        d = self.read_program_address(0x800FFE)
+        a = self._read_program_address(0x800FF8)
+        b = self._read_program_address(0x800FFA)
+        c = self._read_program_address(0x800FFC)
+        d = self._read_program_address(0x800FFE)
         val = d | (c << 16) | (b << 32) | (a << 48)
         return val
 


### PR DESCRIPTION
This changes the behavior of auto connect when more than one PSLab is detected. Previously, the device which appeared first in port enumeration would be connected to. Now, SerialHandler will raise an exception, list detected devices, and ask the user to explicitly choose which device they want to connect to.

Also adds a new function, pslab.serial_handler.detect, which returns a dictionary of port names where PSLabs were detected and their version numbers, e.g:

{'/dev/ttyUSB3': 'PSLab V6\n', '/dev/ttyACM3': 'PSLab V5\n'}

If only a single device is detected, auto connect works the same as before.