### PR TITLE
Add SerialHandler.get_long

### DIFF
--- a/pslab/serial_handler.py
+++ b/pslab/serial_handler.py
@@ -95,6 +95,8 @@ class SerialHandler:
         update_wrapper(self.send_byte, self._send)
         self.send_int = partial(self._send, size=2)
         update_wrapper(self.send_int, self._send)
+        self.send_long = partial(self._send, size=4)
+        update_wrapper(self.send_long, self._send)
         self.get_byte = partial(self._receive, size=1)
         update_wrapper(self.get_byte, self._receive)
         self.get_int = partial(self._receive, size=2)


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds a new method, SerialHandler.send_long, to the SerialHandler class, enabling the sending of 4-byte data.

- **New Features**:
    - Introduced SerialHandler.send_long method for sending 4-byte data.

<!-- Generated by sourcery-ai[bot]: end summary -->