### PR TITLE
Fix UART passthrough on v6

### DIFF
--- a/pslab/bus/uart.py
+++ b/pslab/bus/uart.py
@@ -170,7 +170,9 @@ class _UARTPrimitive:
         self._device.send_byte(CP.UART_2)
         self._device.send_byte(CP.SEND_BYTE)
         self._device.send_byte(data)
-        self._device.get_ack()
+
+        if self._device.firmware.major < 3:
+            self._device.get_ack()
 
     def _write_int(self, data: int):
         """Write a single int to the UART bus.

--- a/pslab/protocol.py
+++ b/pslab/protocol.py
@@ -1,5 +1,6 @@
 """TODO"""
 
+import enum
 import struct
 
 
@@ -179,16 +180,16 @@ FETCH_COUNT = Byte.pack(26)
 FILL_BUFFER = Byte.pack(27)
 
 # /*---------- BAUDRATE for main comm channel----*/
-SETBAUD = Byte.pack(12)
-BAUD9600 = Byte.pack(1)
-BAUD14400 = Byte.pack(2)
-BAUD19200 = Byte.pack(3)
-BAUD28800 = Byte.pack(4)
-BAUD38400 = Byte.pack(5)
-BAUD57600 = Byte.pack(6)
-BAUD115200 = Byte.pack(7)
-BAUD230400 = Byte.pack(8)
-BAUD1000000 = Byte.pack(9)
+SETBAUD_LEGACY = Byte.pack(12)
+BAUD9600_LEGACY = Byte.pack(1)
+BAUD14400_LEGACY = Byte.pack(2)
+BAUD19200_LEGACY = Byte.pack(3)
+BAUD28800_LEGACY = Byte.pack(4)
+BAUD38400_LEGACY = Byte.pack(5)
+BAUD57600_LEGACY = Byte.pack(6)
+BAUD115200_LEGACY = Byte.pack(7)
+BAUD230400_LEGACY = Byte.pack(8)
+BAUD1000000_LEGACY = Byte.pack(9)
 
 # /*-----------NRFL01 radio module----------*/
 NRFL01 = Byte.pack(13)
@@ -229,7 +230,8 @@ HCSR04_HEADER = Byte.pack(2)
 # --------COMMUNICATION PASSTHROUGHS--------
 # Data sent to the device is directly routed to output ports such as (SCL, SDA for UART)
 
-PASSTHROUGHS = Byte.pack(15)
+PASSTHROUGHS = Byte.pack(12)
+PASSTHROUGHS_LEGACY = Byte.pack(15)
 PASS_UART = Byte.pack(1)
 
 # /*--------STOP STREAMING------*/

--- a/pslab/sciencelab.py
+++ b/pslab/sciencelab.py
@@ -282,12 +282,8 @@ class ScienceLab(SerialHandler):
         self.send_int(value)
         self.get_ack()
 
-    def enable_uart_passthrough(self, baudrate: int, persist=False):
+    def enable_uart_passthrough(self, baudrate: int):
         """Relay all data received by the device to TXD/RXD.
-
-        If a period > 0.5 seconds elapses between two transmit/receive events,
-        the device resets and resumes normal mode. This timeout feature has
-        been implemented in lieu of a hard reset option.
 
         Can be used to load programs into secondary microcontrollers with
         bootloaders such ATMEGA or ESP8266
@@ -295,17 +291,29 @@ class ScienceLab(SerialHandler):
         Parameters
         ----------
         baudrate : int
-            Baudrate of the UART bus.
-        persist : bool, optional
-            If set to True, the device will stay in passthrough mode until the
-            next power cycle. Otherwise(default scenario), the device will
-            return to normal operation if no data is sent/received for a period
-            greater than one second at a time.
+            Baudrate of the UART2 bus.
         """
+        if self.firmware.major < 3:
+            self._uart_passthrough_legacy(baudrate)
+        else:
+            self._uart_passthrough(baudrate)
+
+    def _uart_passthrough(self, baudrate: int) -> None:
         self.send_byte(CP.PASSTHROUGHS)
         self.send_byte(CP.PASS_UART)
-        self.send_byte(1 if persist else 0)
-        self.send_int(int(round(((64e6 / baudrate) / 4) - 1)))
+        self.send_int(self._get_brgval(baudrate))
+        self.interface.baudrate = baudrate
+
+    def _uart_passthrough_legacy(self, baudrate: int) -> None:
+        self.send_byte(CP.PASSTHROUGHS_LEGACY)
+        self.send_byte(CP.PASS_UART)
+        disable_watchdog = 1
+        self.send_byte(disable_watchdog)
+        self.send_int(self._get_brgval(baudrate))
+
+    @staticmethod
+    def _get_brgval(baudrate: int) -> int:
+        return int((CP.CLOCK_RATE / (4 * baudrate)) - 1)
 
     def read_log(self):
         """Read hardware debug log.


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix UART passthrough on v6 by removing the persist parameter and implementing separate methods for legacy and current firmware versions. Refactor baud rate constants to improve code clarity and compatibility.

Bug Fixes:
- Fix UART passthrough functionality by removing the persist parameter and adjusting the implementation to handle different firmware versions.

Enhancements:
- Introduce separate methods for UART passthrough to support legacy and current firmware versions, improving compatibility.
- Refactor baud rate constants to distinguish between legacy and current implementations, enhancing code clarity.

<!-- Generated by sourcery-ai[bot]: end summary -->