### PR TITLE
Add get_firmware_version

### DIFF
--- a/pslab/protocol.py
+++ b/pslab/protocol.py
@@ -152,6 +152,7 @@ GET_FREQUENCY = Byte.pack(3)
 GET_INDUCTANCE = Byte.pack(4)
 
 GET_VERSION = Byte.pack(5)
+GET_FW_VERSION = Byte.pack(6)
 
 RETRIEVE_BUFFER = Byte.pack(8)
 GET_HIGH_FREQUENCY = Byte.pack(9)


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add functionality to retrieve the firmware version in the serial handler by introducing a new method `get_firmware_version` and a corresponding command `GET_FW_VERSION` in the protocol.

New Features:
- Introduce a method `get_firmware_version` in the `serial_handler.py` to retrieve the firmware version as a tuple of major, minor, and patch numbers.

Enhancements:
- Add a new command `GET_FW_VERSION` in `protocol.py` to support the firmware version retrieval functionality.

<!-- Generated by sourcery-ai[bot]: end summary -->