### PR TITLE
Add note and link to Windows driver to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ pslab-python can be installed from PyPI:
 
 **Note**: Linux users must either install a udev rule by running 'pslab install' as root, or be part of the 'dialout' group in order for pslab-python to be able to communicate with the PSLab device.
 
+**Note**: Windows users who use the PSLab v6 device must download and install the CP210x Windows Drivers from the [Silicon Labs website](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers?tab=downloads).
+
 **Note**: If you are only interested in using PSLab as an acquisition device without a display/GUI, only pslab-python needs to be installed. If you would like a GUI, install the [pslab-desktop app](https://github.com/fossasia/pslab-desktop) and follow the instructions of the Readme in that repo.
 
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pslab-python can be installed from PyPI:
 
 **Note**: Linux users must either install a udev rule by running 'pslab install' as root, or be part of the 'dialout' group in order for pslab-python to be able to communicate with the PSLab device.
 
-**Note**: Windows users who use the PSLab v6 device must download and install the CP210x Windows Drivers from the [Silicon Labs website](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers?tab=downloads).
+**Note**: Windows users who use the PSLab v6 device must download and install the CP210x Windows Drivers from the [Silicon Labs website](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers?tab=downloads) in order for pslab-python to be able to communicate with the PSLab device.
 
 **Note**: If you are only interested in using PSLab as an acquisition device without a display/GUI, only pslab-python needs to be installed. If you would like a GUI, install the [pslab-desktop app](https://github.com/fossasia/pslab-desktop) and follow the instructions of the Readme in that repo.
 


### PR DESCRIPTION
Added a note for Windows users to install the appropriate driver if they use the v6 board.

Fixes https://github.com/fossasia/pslab-python/issues/235

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the README to include instructions for Windows users to install the necessary drivers for the PSLab v6 device.

Documentation:
- Add a note to the README for Windows users to install the CP210x Windows Drivers from the Silicon Labs website when using the PSLab v6 device.

<!-- Generated by sourcery-ai[bot]: end summary -->