### PR TITLE
Fix out-of-tree commits in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,28 @@
 
 ### Changed
 
-- __Breaking__: Do not autoconnect on `SerialHandler` zero-arg instantiation ([`2ae3f09`](https://github.com/fossasia/pslab-python/commit/2ae3f0968fbaac9b99d7fc037fd82f16660cd6e1)) (Alexander Bessman)
-- __Breaking__: Deprecate `serial_handler` in favor of `connection` ([`0605386`](https://github.com/fossasia/pslab-python/commit/0605386f74f5929008dd7b8396e6bfe9933c6e92)) (Alexander Bessman)
-- __Breaking__: Move `SerialHandler` to `connection` ([`2ae3f09`](https://github.com/fossasia/pslab-python/commit/2ae3f0968fbaac9b99d7fc037fd82f16660cd6e1)) (Alexander Bessman)
-- __Breaking__: Move `detect` to `connection` ([`2ae3f09`](https://github.com/fossasia/pslab-python/commit/2ae3f0968fbaac9b99d7fc037fd82f16660cd6e1)) (Alexander Bessman)
-- __Breaking__: Make `check_serial_access_permission` private ([`2ae3f09`](https://github.com/fossasia/pslab-python/commit/2ae3f0968fbaac9b99d7fc037fd82f16660cd6e1)) (Alexander Bessman)
-- __Breaking__: Move `ADCBufferMixin` to `instrument.buffer` ([`2ae3f09`](https://github.com/fossasia/pslab-python/commit/2ae3f0968fbaac9b99d7fc037fd82f16660cd6e1)) (Alexander Bessman)
+- __Breaking__: Do not autoconnect on `SerialHandler` zero-arg instantiation ([`e70d01d`](https://github.com/fossasia/pslab-python/commit/e70d01d8761b7c0d8446994447849561450d5200)) (Alexander Bessman)
+- __Breaking__: Deprecate `serial_handler` in favor of `connection` ([`bc53dd3`](https://github.com/fossasia/pslab-python/commit/bc53dd38830f3d70e908e2c4f1ae797a809231a6)) (Alexander Bessman)
+- __Breaking__: Move `SerialHandler` to `connection` ([`e70d01d`](https://github.com/fossasia/pslab-python/commit/e70d01d8761b7c0d8446994447849561450d5200)) (Alexander Bessman)
+- __Breaking__: Move `detect` to `connection` ([`e70d01d`](https://github.com/fossasia/pslab-python/commit/e70d01d8761b7c0d8446994447849561450d5200)) (Alexander Bessman)
+- __Breaking__: Make `check_serial_access_permission` private ([`e70d01d`](https://github.com/fossasia/pslab-python/commit/e70d01d8761b7c0d8446994447849561450d5200)) (Alexander Bessman)
+- __Breaking__: Move `ADCBufferMixin` to `instrument.buffer` ([`e70d01d`](https://github.com/fossasia/pslab-python/commit/e70d01d8761b7c0d8446994447849561450d5200)) (Alexander Bessman)
 
 ### Added
 
-- Add common `connection` module for different control interfaces ([`2ae3f09`](https://github.com/fossasia/pslab-python/commit/2ae3f0968fbaac9b99d7fc037fd82f16660cd6e1)) (Alexander Bessman)
-- Add `WLANHandler` class for controlling the PSLab over WLAN ([`f595d01`](https://github.com/fossasia/pslab-python/commit/f595d01b51b8d3d2e7c6b8c8c1e4a051fcb793df)) (Alexander Bessman)
-- Add `ConnectionHandler` base class for `SerialHandler` and `WLANHandler` ([`2ae3f09`](https://github.com/fossasia/pslab-python/commit/2ae3f0968fbaac9b99d7fc037fd82f16660cd6e1)) (Alexander Bessman)
-- Add `connection.autoconnect` function ([`2ae3f09`](https://github.com/fossasia/pslab-python/commit/2ae3f0968fbaac9b99d7fc037fd82f16660cd6e1)) (Alexander Bessman)
-- Add `instrument.buffer` module ([`2ae3f09`](https://github.com/fossasia/pslab-python/commit/2ae3f0968fbaac9b99d7fc037fd82f16660cd6e1)) (Alexander Bessman)
+- Add common `connection` module for different control interfaces ([`e70d01d`](https://github.com/fossasia/pslab-python/commit/e70d01d8761b7c0d8446994447849561450d5200)) (Alexander Bessman)
+- Add `WLANHandler` class for controlling the PSLab over WLAN ([`1316df4`](https://github.com/fossasia/pslab-python/commit/1316df452bff97106dc9313fe9458c93d7f954ab)) (Alexander Bessman)
+- Add `ConnectionHandler` base class for `SerialHandler` and `WLANHandler` ([`e70d01d`](https://github.com/fossasia/pslab-python/commit/e70d01d8761b7c0d8446994447849561450d5200)) (Alexander Bessman)
+- Add `connection.autoconnect` function ([`e70d01d`](https://github.com/fossasia/pslab-python/commit/e70d01d8761b7c0d8446994447849561450d5200)) (Alexander Bessman)
+- Add `instrument.buffer` module ([`e70d01d`](https://github.com/fossasia/pslab-python/commit/e70d01d8761b7c0d8446994447849561450d5200)) (Alexander Bessman)
 
 ### Removed
 
-- __Breaking__: Remove `SerialHandler.wait_for_data` ([`2ae3f09`](https://github.com/fossasia/pslab-python/commit/2ae3f0968fbaac9b99d7fc037fd82f16660cd6e1)) (Alexander Bessman)
+- __Breaking__: Remove `SerialHandler.wait_for_data` ([`e70d01d`](https://github.com/fossasia/pslab-python/commit/e70d01d8761b7c0d8446994447849561450d5200)) (Alexander Bessman)
 
 ### Fixed
 
-- Fix SPI configuration sending one byte too few ([`bd11b73`](https://github.com/fossasia/pslab-python/commit/bd11b7319af7768a6929ba35d0b5e81b43ee5033)) (Alexander Bessman)
+- Fix SPI configuration sending one byte too few ([`a3d88bb`](https://github.com/fossasia/pslab-python/commit/a3d88bbfeee8cdb012d033c6c80f40b971802851)) (Alexander Bessman)
 
 ## [3.1.1] - 2025-01-05
 


### PR DESCRIPTION
Commit references got messed up by previous PR rebase.

## Summary by Sourcery

Updates the changelog to correct commit references that were broken during a rebase.

Bug Fixes:
- Fixes incorrect commit references in the changelog due to a previous rebase.

Chores:
- Updates commit SHAs in the changelog to reflect the correct commits.