### PR TITLE
feat: Added RoboticArm 

### DIFF
--- a/pslab/external/motor.py
+++ b/pslab/external/motor.py
@@ -87,7 +87,20 @@ class RoboticArm:
         self.servos = servos
 
     def run_schedule(self, timeline: List[List[int]], time_step: float = 1.0) -> None:
-        """Move servos based on a time-based angle schedule."""
+        """Run a time-based schedule to move servos.
+
+        Parameters
+        ----------
+        timeline : List[List[int]]
+            A list of timesteps,where each sublist represents one timestep,
+            with angles corresponding to each servo.
+
+        time_step : float, optional
+             Delay in seconds between each timestep. Default is 1.0.
+        """
+        if len(timeline[0]) != len(self.servos):
+            raise ValueError("Each timestep must specify an angle for every servo")
+
         tl_len = len(timeline[0])
         if not all(len(tl) == tl_len for tl in timeline):
             raise ValueError("All timeline entries must have the same length")


### PR DESCRIPTION
Fixes #252 #253 

## Changes  
**Added `RoboticArm` class to `pslab.external.motor`**  
This class enables controlling RoboticArm

**Supports control of up to 4 servos via `Servo` class**  
Internally uses existing `Servo` objects, validating servo count and managing individual angle settings

**Implemented `run_schedule()` to move RoboticArm according to a timeline**  
Each servo position is updated per second based on a time-dependent list of angle

## Summary by Sourcery

Add RoboticArm class to motor module enabling multi-servo control and timed movement scheduling

New Features:
- Add RoboticArm class with validation for up to 4 Servo instances
- Implement run_schedule method to execute servo angle timelines at one-second intervals