### PR TITLE
Add CSV and JSON export utilities for PSLab sensor data

### DIFF
--- a/pslab/utils/data_export.py
+++ b/pslab/utils/data_export.py
@@ -1,0 +1,19 @@
+import csv
+import json
+
+def export_to_csv(data, filename):
+    """
+    data: list of dictionaries
+    """
+    if not data:
+        return
+
+    with open(filename, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=data[0].keys())
+        writer.writeheader()
+        writer.writerows(data)
+
+
+def export_to_json(data, filename):
+    with open(filename, "w") as f:
+        json.dump(data, f, indent=4)

--- a/pslab/utils/data_export.py
+++ b/pslab/utils/data_export.py
@@ -1,19 +1,38 @@
 import csv
 import json
+import io
 
-def export_to_csv(data, filename):
+def export_to_csv(data, target, fieldnames=None):
     """
-    data: list of dictionaries
+    Exports a list of dictionaries to a CSV file or file-like object.
     """
     if not data:
-        return
+        raise ValueError("No data provided for export.")
 
-    with open(filename, "w", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=data[0].keys())
+    # Determine if target is a path (str) or a file-like object
+    is_path = isinstance(target, str)
+    f = open(target, "w", newline="", encoding="utf-8") if is_path else target
+
+    try:
+        writer = csv.DictWriter(f, fieldnames=fieldnames or data[0].keys())
         writer.writeheader()
         writer.writerows(data)
+    finally:
+        if is_path:
+            f.close()
 
+def export_to_json(data, target):
+    """
+    Exports data to a JSON file or file-like object.
+    """
+    if not data:
+        raise ValueError("No data provided for export.")
 
-def export_to_json(data, filename):
-    with open(filename, "w") as f:
+    is_path = isinstance(target, str)
+    f = open(target, "w", encoding="utf-8") if is_path else target
+
+    try:
         json.dump(data, f, indent=4)
+    finally:
+        if is_path:
+            f.close()


### PR DESCRIPTION
This PR adds utility functions to export PSLab sensor data
to CSV and JSON formats.

- Useful for IoT data logging and analysis
- Pure Python implementation
- Includes basic pytest-based tests
- No hardware required

This improves data usability for PSLab users.

## Summary by Sourcery

Add utility module for exporting PSLab sensor data to common file formats.

New Features:
- Introduce CSV export helper for writing lists of dictionaries to files with headers.
- Introduce JSON export helper for serializing data collections to formatted JSON files.