### PR TITLE
Add CSV and JSON export utilities for PSLab sensor data

### DIFF
--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -1,0 +1,18 @@
+import pytest
+from pslab.utils.data_export import export_to_csv, export_to_json
+
+def test_export_csv_creates_file(tmp_path):
+    data = [{"a": 1, "b": 2}]
+    file_path = tmp_path / "data.csv"
+    export_to_csv(data, str(file_path))
+    assert file_path.exists()
+
+def test_export_json_creates_file(tmp_path):
+    data = [{"x": 10}]
+    file_path = tmp_path / "data.json"
+    export_to_json(data, str(file_path))
+    assert file_path.exists()
+
+def test_export_empty_data_raises_error():
+    with pytest.raises(ValueError):
+        export_to_csv([], "dummy.csv")

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -1,17 +1,38 @@
+import csv
+import json
 import pytest
 from pslab.utils.data_export import export_to_csv, export_to_json
+
 
 def test_export_csv_creates_file(tmp_path):
     data = [{"a": 1, "b": 2}]
     file_path = tmp_path / "data.csv"
+
     export_to_csv(data, str(file_path))
     assert file_path.exists()
+
+    with file_path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        assert reader.fieldnames == ["a", "b"]
+
+        rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]["a"] == "1"
+        assert rows[0]["b"] == "2"
+
 
 def test_export_json_creates_file(tmp_path):
     data = [{"x": 10}]
     file_path = tmp_path / "data.json"
+
     export_to_json(data, str(file_path))
     assert file_path.exists()
+
+    with file_path.open("r", encoding="utf-8") as f:
+        loaded = json.load(f)
+
+    assert loaded == data
+
 
 def test_export_empty_data_raises_error():
     with pytest.raises(ValueError):


### PR DESCRIPTION
This PR adds utility functions to export PSLab sensor data
to CSV and JSON formats.

- Useful for IoT data logging and analysis
- Pure Python implementation
- Includes basic pytest-based tests
- No hardware required

This improves data usability for PSLab users.

## Summary by Sourcery

Add utilities for exporting PSLab sensor data to common file formats and ensure they are covered by basic tests.

New Features:
- Introduce helpers to export PSLab sensor data to CSV and JSON files.

Tests:
- Add pytest-based tests verifying CSV and JSON export create output files and that exporting empty data raises an error.