### PR TITLE
feat: Add MockHandler for hardware-less simulation

### DIFF
--- a/pslab/mock_handler.py
+++ b/pslab/mock_handler.py
@@ -1,0 +1,111 @@
+"""
+MockHandler for PSLab.
+
+This module provides a software simulation of the PSLab hardware interface.
+It allows developers to test signal processing and communication logic
+without physical hardware by injecting custom response data.
+"""
+
+import logging
+import struct
+from typing import Dict, Optional, Union
+
+class MockHandler:
+    """
+    A mock communication handler that simulates the PSLab hardware.
+    """
+
+    def __init__(self, port: Optional[str] = None):
+        self.connected = False
+        self.port = port or "MOCK_PORT"
+        self.response_map: Dict[bytes, bytes] = {}
+        self.read_buffer = bytearray()
+        self.logger = logging.getLogger(__name__)
+
+    def open(self, port: Optional[str] = None) -> None:
+        self.connected = True
+        self.logger.info(f"MockHandler connected on {self.port}")
+
+    def close(self) -> None:
+        self.connected = False
+        self.read_buffer.clear()
+        self.logger.info("MockHandler disconnected.")
+
+    def write(self, data: bytes) -> int:
+        if not self.connected:
+            raise RuntimeError("Attempted to write to closed MockHandler.")
+
+        # Check for registered responses
+        match_found = False
+        for command, response in self.response_map.items():
+            if data.startswith(command):
+                self.read_buffer.extend(response)
+                match_found = True
+                break
+        
+        if not match_found:
+            self.logger.debug(f"Write: {data.hex()} (No specific response mapped)")
+
+        return len(data)
+
+    def read(self, size: int = 1) -> bytes:
+        if not self.connected:
+            raise RuntimeError("Attempted to read from closed MockHandler.")
+
+        if len(self.read_buffer) < size:
+            self.logger.warning(f"MockHandler: Requested {size} bytes, but only {len(self.read_buffer)} available.")
+            # Return what we have, then empty bytes
+            data = self.read_buffer[:]
+            self.read_buffer.clear()
+            return bytes(data)
+
+        data = self.read_buffer[:size]
+        self.read_buffer = self.read_buffer[size:]
+        return bytes(data)
+
+    def clear_buffer(self) -> None:
+        self.read_buffer.clear()
+
+    # --- Interface Compatibility Methods ---
+
+    def send_byte(self, val: Union[int, bytes]) -> None:
+        """
+        Sends a single byte to the device.
+        Handles both integer (0-255) and single-byte bytes objects.
+        """
+        if isinstance(val, int):
+            self.write(bytes([val]))
+        elif isinstance(val, bytes):
+            self.write(val)
+        else:
+            raise TypeError(f"send_byte expects int or bytes, got {type(val)}")
+
+    def send_int(self, val: int) -> None:
+        """Sends a 16-bit integer to the device."""
+        self.write(struct.pack('<H', val)) # Little-endian unsigned short
+
+    def read_byte(self) -> int:
+        """Reads a single byte and returns it as an integer."""
+        data = self.read(1)
+        if not data:
+            return 0 
+        return data[0]
+    
+    def read_int(self) -> int:
+        """Reads two bytes and interprets them as a 16-bit integer."""
+        data = self.read(2)
+        if len(data) < 2:
+            return 0
+        return struct.unpack('<H', data)[0]
+
+    def get_ack(self) -> bool:
+        """Simulates receiving an acknowledgement from the device."""
+        return True
+
+    # --- Developer Control Methods ---
+
+    def register_response(self, command: bytes, response: bytes) -> None:
+        self.response_map[command] = response
+
+    def inject_data(self, data: bytes) -> None:
+        self.read_buffer.extend(data)

--- a/pslab/mock_handler.py
+++ b/pslab/mock_handler.py
@@ -56,12 +56,26 @@ class MockHandler:
         return len(data)
 
     def read(self, size: int = 1) -> bytes:
+        """
+        Read bytes from the mock buffer.
+        
+        Parameters
+        ----------
+        size : int
+            Number of bytes to read.
+            
+        Returns
+        -------
+        bytes
+            The data read from the buffer.
+        """
         if not self.connected:
             raise RuntimeError("Attempted to read from closed MockHandler.")
 
-        if len(self.read_buffer) < size:
-            self.logger.warning(f"MockHandler: Requested {size} bytes, but only {len(self.read_buffer)} available.")
-            # Return all currently available bytes and clear the buffer (partial read)
+        available = len(self.read_buffer)
+        if available < size:
+            self.logger.warning(f"MockHandler: Requested {size} bytes, but only {available} available.")
+            # Return what we have, then empty the buffer
             data = self.read_buffer[:]
             self.read_buffer.clear()
             return bytes(data)
@@ -69,6 +83,17 @@ class MockHandler:
         data = self.read_buffer[:size]
         self.read_buffer = self.read_buffer[size:]
         return bytes(data)
+
+    def get_ack(self) -> int:
+        """
+        Simulate receiving an acknowledgement from the device.
+        
+        Returns
+        -------
+        int
+            ACK value (0x01).
+        """
+        return 0x01
 
         if len(self.read_buffer) < size:
             self.logger.warning(f"MockHandler: Requested {size} bytes, but only {len(self.read_buffer)} available.")

--- a/pslab/sciencelab.py
+++ b/pslab/sciencelab.py
@@ -35,7 +35,17 @@ class ScienceLab:
     """
 
     def __init__(self, device: ConnectionHandler | None = None, mock: bool = False):
+        """
+        Initialize the ScienceLab interface.
+        
+        :param device: The connection handler (real hardware).
+        :param mock: If True, use the MockHandler for simulation.
+        :raises ValueError: If both 'device' and 'mock=True' are provided.
+        """
         if mock:
+            if device is not None:
+                raise ValueError("Cannot initialize ScienceLab with both a physical device and mock=True.")
+            
             self.device = MockHandler()
             self.device.open()
             self.firmware = "MOCK_FW_1.0" # Fake firmware version

--- a/pslab/sciencelab.py
+++ b/pslab/sciencelab.py
@@ -19,6 +19,17 @@ from pslab.instrument.power_supply import PowerSupply
 from pslab.instrument.waveform_generator import PWMGenerator, WaveformGenerator
 
 
+class MockFirmwareVersion:
+    """Mock firmware version object to mimic the real behavior."""
+    def __init__(self):
+        self.major = 1
+        self.minor = 0
+        self.patch = 0
+        self.version = "1.0.0"
+    
+    def __str__(self):
+        return self.version
+    
 class ScienceLab:
     """Aggregate interface for the PSLab's instruments.
 
@@ -37,10 +48,18 @@ class ScienceLab:
     def __init__(self, device: ConnectionHandler | None = None, mock: bool = False):
         """
         Initialize the ScienceLab interface.
+
+        Parameters
+        ----------
+        device : ConnectionHandler, optional
+            The connection handler (real hardware).
+        mock : bool, optional
+            If True, use the MockHandler for simulation.
         
-        :param device: The connection handler (real hardware).
-        :param mock: If True, use the MockHandler for simulation.
-        :raises ValueError: If both 'device' and 'mock=True' are provided.
+        Raises
+        ------
+        ValueError
+            If both 'device' and 'mock=True' are provided.
         """
         if mock:
             if device is not None:
@@ -48,16 +67,11 @@ class ScienceLab:
             
             self.device = MockHandler()
             self.device.open()
-            self.firmware = "MOCK_FW_1.0" # Fake firmware version
+            # FIX: Use an object so .major/.minor access works
+            self.firmware = MockFirmwareVersion()
         else:
             self.device = device if device is not None else autoconnect()
             self.firmware = self.device.get_firmware_version()
-        self.logic_analyzer = LogicAnalyzer(device=self.device)
-        self.oscilloscope = Oscilloscope(device=self.device)
-        self.waveform_generator = WaveformGenerator(device=self.device)
-        self.pwm_generator = PWMGenerator(device=self.device)
-        self.multimeter = Multimeter(device=self.device)
-        self.power_supply = PowerSupply(device=self.device)
 
     @property
     def temperature(self):

--- a/pslab/sciencelab.py
+++ b/pslab/sciencelab.py
@@ -6,7 +6,7 @@ collection.
 """
 
 from __future__ import annotations
-
+from .mock_handler import MockHandler
 import time
 from typing import Iterable, List
 
@@ -34,9 +34,14 @@ class ScienceLab:
     nrf : pslab.peripherals.NRF24L01
     """
 
-    def __init__(self, device: ConnectionHandler | None = None):
-        self.device = device if device is not None else autoconnect()
-        self.firmware = self.device.get_firmware_version()
+    def __init__(self, device: ConnectionHandler | None = None, mock: bool = False):
+        if mock:
+            self.device = MockHandler()
+            self.device.open()
+            self.firmware = "MOCK_FW_1.0" # Fake firmware version
+        else:
+            self.device = device if device is not None else autoconnect()
+            self.firmware = self.device.get_firmware_version()
         self.logic_analyzer = LogicAnalyzer(device=self.device)
         self.oscilloscope = Oscilloscope(device=self.device)
         self.waveform_generator = WaveformGenerator(device=self.device)


### PR DESCRIPTION
**Description**
This PR introduces a `MockHandler` to the `pslab-python` library. It allows developers to initialize the `ScienceLab` class in a simulation mode (`mock=True`), enabling testing and development without a physical PSLab device connected.

**Changes Made**
* **New Module:** Added `pslab/mock_handler.py` which mimics the `ConnectionHandler` interface.
* **Integration:** Updated `pslab/sciencelab.py` to support a `mock` boolean argument in `__init__`.
* **Functionality:** Implemented `read`, `write`, `send_byte`, and signal injection methods to allow programmatic control over "hardware" responses.
* **Compatibility:** Addressed type handling to ensure smooth operation with existing instrument classes (e.g., Oscilloscope).

**How to Test**
```python
from pslab.sciencelab import ScienceLab

# Initialize in mock mode
device = ScienceLab(mock=True)

# Verify firmware version is set to mock default
print(device.firmware) # Expected: 'MOCK_FW_1.0'

# Verify signal injection
device.device.register_response(b'\x01', b'\x99')
device.device.write(b'\x01')
print(device.device.read(1)) # Expected: b'\x99'

## Summary by Sourcery

Add a mock communication handler and hook it into ScienceLab to enable hardware-less simulation of the PSLab device.

New Features:
- Allow initializing ScienceLab in a mock mode via a new mock flag, using a simulated device instead of a physical connection.
- Introduce a MockHandler that simulates the ConnectionHandler interface, including read/write and basic data/ack handling, for use in tests and development.