### PR TITLE
Fix: Update SPI driver for firmware v3 by using _BURST commands

### DIFF
--- a/pslab/bus/spi.py
+++ b/pslab/bus/spi.py
@@ -51,9 +51,9 @@ class _SPIPrimitive:
     """
 
     _TRANSFER_COMMANDS_MAP = {
-        8: CP.SEND_SPI8,
-        16: CP.SEND_SPI16,
-    }  # PSLab only supports 8 and 16 bits.
+        8: CP.SEND_SPI8_BURST,
+        16: CP.SEND_SPI16_BURST,
+    } # PSLab only supports 8 and 16 bits.
     _INTEGER_TYPE_MAP = {
         8: CP.Byte,
         16: CP.ShortInt,
@@ -508,9 +508,7 @@ class SPISlave(_SPIPrimitive):
         data_in : int
             Data returned by slave device.
         """
-        self._start()
         data_in = self._transfer(data, 8)
-        self._stop()
 
         return data_in
 
@@ -527,9 +525,7 @@ class SPISlave(_SPIPrimitive):
         data_in : int
             Data returned by slave device.
         """
-        self._start()
         data_in = self._transfer(data, 16)
-        self._stop()
 
         return data_in
 
@@ -546,9 +542,7 @@ class SPISlave(_SPIPrimitive):
         data_in : list of int
             List of 8-bit data returned by slave device.
         """
-        self._start()
         data_in = self._transfer_bulk(data, 8)
-        self._stop()
 
         return data_in
 
@@ -565,9 +559,7 @@ class SPISlave(_SPIPrimitive):
         data_in : list of int
             List of 16-bit data returned by slave device.
         """
-        self._start()
         data_in = self._transfer_bulk(data, 16)
-        self._stop()
 
         return data_in
 
@@ -579,9 +571,7 @@ class SPISlave(_SPIPrimitive):
         int
             Data returned by slave device.
         """
-        self._start()
         data_in = self._read(8)
-        self._stop()
 
         return data_in
 
@@ -593,9 +583,7 @@ class SPISlave(_SPIPrimitive):
         int
             Data returned by slave device.
         """
-        self._start()
         data_in = self._read(16)
-        self._stop()
 
         return data_in
 
@@ -612,9 +600,7 @@ class SPISlave(_SPIPrimitive):
         list of int
             List of 8-bit data returned by slave device.
         """
-        self._start()
         data_in = self._read_bulk(data_to_read, 8)
-        self._stop()
 
         return data_in
 
@@ -631,9 +617,7 @@ class SPISlave(_SPIPrimitive):
         list of int
             List of 16-bit date returned by slave device.
         """
-        self._start()
         data_in = self._read_bulk(data_to_read, 16)
-        self._stop()
 
         return data_in
 

--- a/pslab/bus/spi.py
+++ b/pslab/bus/spi.py
@@ -214,29 +214,6 @@ class _SPIPrimitive:
             cls._smp,
         )
 
-    def _start(self):
-        """Select SPI channel to enable.
-
-        Basically sets the relevant chip select pin to LOW.
-
-        External ChipSelect pins:
-            version < 5 : {6, 7} # RC5, RC4 (dropped support)
-            version == 5 : {} (don't have any external CS pins)
-            version == 6 : {7} # RC4
-        """
-        self._device.send_byte(CP.SPI_HEADER)
-        self._device.send_byte(CP.START_SPI)
-        self._device.send_byte(7)  # SPI.CS v6
-        # No ACK because `RESPONSE == DO_NOT_BOTHER` in firmware.
-
-    def _stop(self):
-        """Select SPI channel to disable.
-
-        Sets the relevant chip select pin to HIGH.
-        """
-        self._device.send_byte(CP.SPI_HEADER)
-        self._device.send_byte(CP.STOP_SPI)
-        self._device.send_byte(7)  # SPI.CS v6
 
     def _transfer(self, data: int, bits: int) -> int:
         """Send data over SPI and receive data from SPI simultaneously.

--- a/tests/test_spi.py
+++ b/tests/test_spi.py
@@ -31,7 +31,6 @@ CS = "LA3"
 SPIMaster._primary_prescaler = PPRE = 0
 SPIMaster._secondary_prescaler = SPRE = 0
 # Static value 100kHz used because instance property '_frequency' cannot be accessed on the class.
-PWM_FREQUENCY = 100000.0
 MICROSECONDS = 1e-6
 RELTOL = 0.05
 # Number of expected logic level changes.
@@ -60,9 +59,11 @@ def slave(handler: SerialHandler) -> SPISlave:
 
 
 @pytest.fixture
-def la(handler: SerialHandler) -> LogicAnalyzer:
+def la(handler: SerialHandler, spi_master: SPIMaster) -> LogicAnalyzer:
     pwm = PWMGenerator(handler)
-    pwm.generate(SDI[1], PWM_FREQUENCY, 0.5)
+    # Bot ka formula: Static frequency ki jagah dynamic use karein
+    pwm_frequency = spi_master._frequency * 2 / 3
+    pwm.generate(SDI[1], pwm_frequency, 0.5)
     return LogicAnalyzer(handler)
 
 

--- a/tests/test_spi.py
+++ b/tests/test_spi.py
@@ -30,7 +30,7 @@ SDI = ["LA4", "SQ1"]
 CS = "LA3"
 SPIMaster._primary_prescaler = PPRE = 0
 SPIMaster._secondary_prescaler = SPRE = 0
-PWM_FERQUENCY = SPIMaster._frequency * 2 / 3
+PWM_FREQUENCY = 1000
 MICROSECONDS = 1e-6
 RELTOL = 0.05
 # Number of expected logic level changes.
@@ -61,7 +61,7 @@ def slave(handler: SerialHandler) -> SPISlave:
 @pytest.fixture
 def la(handler: SerialHandler) -> LogicAnalyzer:
     pwm = PWMGenerator(handler)
-    pwm.generate(SDI[1], PWM_FERQUENCY, 0.5)
+    pwm.generate(SDI[1], PWM_FREQUENCY, 0.5)
     return LogicAnalyzer(handler)
 
 
@@ -73,7 +73,7 @@ def verify_value(
     smp: int = 0,
 ):
     sck_ts = sck_timestamps[smp::2]
-    pwm_half_period = ((1 / PWM_FERQUENCY) * 1e6) / 2  # microsecond
+    pwm_half_period = ((1 / PWM_FREQUENCY) * 1e6) / 2  # microsecond
 
     pattern = ""
     for t in sck_ts:

--- a/tests/test_spi.py
+++ b/tests/test_spi.py
@@ -30,7 +30,8 @@ SDI = ["LA4", "SQ1"]
 CS = "LA3"
 SPIMaster._primary_prescaler = PPRE = 0
 SPIMaster._secondary_prescaler = SPRE = 0
-PWM_FREQUENCY = 1000
+# Static value 100kHz used because instance property '_frequency' cannot be accessed on the class.
+PWM_FREQUENCY = 100000.0
 MICROSECONDS = 1e-6
 RELTOL = 0.05
 # Number of expected logic level changes.

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -16,7 +16,8 @@ from pslab.connection import SerialHandler
 WRITE_DATA = 0x55
 TXD2 = "LA1"
 RXD2 = "SQ1"
-PWM_FREQUENCY = 1000
+# Static value 500kHz (half of default 1MHz baudrate) used as instance property cannot be accessed here.
+PWM_FREQUENCY = 500000.0
 MICROSECONDS = 1e-6
 RELTOL = 0.05
 # Number of expected logic level changes.

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -16,7 +16,7 @@ from pslab.connection import SerialHandler
 WRITE_DATA = 0x55
 TXD2 = "LA1"
 RXD2 = "SQ1"
-PWM_FERQUENCY = UART._baudrate // 2
+PWM_FREQUENCY = 1000
 MICROSECONDS = 1e-6
 RELTOL = 0.05
 # Number of expected logic level changes.
@@ -38,7 +38,7 @@ def la(handler: SerialHandler) -> LogicAnalyzer:
 @pytest.fixture
 def pwm(handler: SerialHandler) -> None:
     pwm = PWMGenerator(handler)
-    pwm.generate(RXD2, PWM_FERQUENCY, 0.5)
+    pwm.generate(RXD2, PWM_FREQUENCY, 0.5)
 
 
 def test_configure(la: LogicAnalyzer, uart: UART):

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -17,7 +17,6 @@ WRITE_DATA = 0x55
 TXD2 = "LA1"
 RXD2 = "SQ1"
 # Static value 500kHz (half of default 1MHz baudrate) used as instance property cannot be accessed here.
-PWM_FREQUENCY = 500000.0
 MICROSECONDS = 1e-6
 RELTOL = 0.05
 # Number of expected logic level changes.
@@ -37,10 +36,11 @@ def la(handler: SerialHandler) -> LogicAnalyzer:
 
 
 @pytest.fixture
-def pwm(handler: SerialHandler) -> None:
+def pwm(handler: SerialHandler, uart: UART) -> None:
     pwm = PWMGenerator(handler)
-    pwm.generate(RXD2, PWM_FREQUENCY, 0.5)
-
+    # 500000.0 ki jagah dynamic formula
+    pwm_frequency = uart._baudrate / 2.0
+    pwm.generate(RXD2, pwm_frequency, 0.5)
 
 def test_configure(la: LogicAnalyzer, uart: UART):
     baudrate = 1000000


### PR DESCRIPTION
### Description
This PR updates the SPI driver to be compatible with firmware v3.
The older firmware relied on `START` and `STOP` commands, which have been deprecated and removed in v3. This PR correctly replaces them with the new `*_BURST` commands.

### Changes Made
- Updated `_TRANSFER_COMMANDS_MAP` to use `CP.SEND_SPI8_BURST` and `CP.SEND_SPI16_BURST`.
- Removed redundant `self._start()` and `self._stop()` calls from `_transfer` and `transfer` functions, as the burst commands now handle the complete transaction internally.

Fixes #262

## Summary by Sourcery

Update SPI bus driver and related tests for compatibility with firmware v3 burst transfer commands.

Bug Fixes:
- Switch SPI transfer command mapping to use burst commands compatible with firmware v3.
- Remove redundant SPI START/STOP calls now handled by burst transfer commands.
- Use fixed PWM frequency constants in SPI and UART tests where instance properties are not accessible.
- Correct PWM frequency constant name in SPI and UART tests to avoid typos and inconsistencies.

Tests:
- Adjust SPI tests to use a static PWM frequency value instead of accessing a non-existent class-level frequency attribute.
- Adjust UART tests to use a static PWM frequency value instead of accessing an instance-only baudrate attribute.